### PR TITLE
Add custom attributes, inline files, and resizable entries

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ script:
   - make test QUIET=1 CFLAGS+="-DLFS_READ_SIZE=512    -DLFS_PROG_SIZE=512"
   - make test QUIET=1 CFLAGS+="-DLFS_BLOCK_COUNT=1023 -DLFS_LOOKAHEAD=2048"
 
+  - make clean test QUIET=1 CFLAGS+="-DLFS_INLINE_MAX=0"
   - make clean test QUIET=1 CFLAGS+="-DLFS_NO_INTRINSICS"
 
   # compile and find the code size with the smallest configuration

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,7 +28,7 @@ script:
   # compile and find the code size with the smallest configuration
   - make clean size
         OBJ="$(ls lfs*.o | tr '\n' ' ')"
-        CFLAGS+="-DLFS_NO{ASSERT,DEBUG,WARN,ERROR}"
+        CFLAGS+="-DLFS_NO_ASSERT -DLFS_NO_DEBUG -DLFS_NO_WARN -DLFS_NO_ERROR"
         | tee sizes
 
   # update status if we succeeded, compare with master if possible

--- a/LICENSE.md
+++ b/LICENSE.md
@@ -1,165 +1,36 @@
-Apache License
-Version 2.0, January 2004
-http://www.apache.org/licenses/
+Copyright (c) 2017, Arm Limited. All rights reserved.
 
-TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+Redistribution and use in source and binary forms, with or without modification,
+are permitted provided that the following conditions are met:
 
-1. Definitions.
+-  Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+-  Redistributions in binary form must reproduce the above copyright notice, this
+   list of conditions and the following disclaimer in the documentation and/or
+   other materials provided with the distribution.
+-  Neither the name of ARM nor the names of its contributors may be used to
+   endorse or promote products derived from this software without specific prior
+   written permission.
 
-"License" shall mean the terms and conditions for use, reproduction, and
-distribution as defined by Sections 1 through 9 of this document.
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS" AND
+ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE IMPLIED
+WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE FOR
+ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES
+(INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES;
+LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
+ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+(INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
+SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
 
-"Licensor" shall mean the copyright owner or entity authorized by the copyright
-owner that is granting the License.
+---
 
-"Legal Entity" shall mean the union of the acting entity and all other entities
-that control, are controlled by, or are under common control with that entity.
-For the purposes of this definition, "control" means (i) the power, direct or
-indirect, to cause the direction or management of such entity, whether by
-contract or otherwise, or (ii) ownership of fifty percent (50%) or more of the
-outstanding shares, or (iii) beneficial ownership of such entity.
+*Note*:
+Individual files contain the following tag instead of the full license text.
 
-"You" (or "Your") shall mean an individual or Legal Entity exercising
-permissions granted by this License.
 
-"Source" form shall mean the preferred form for making modifications, including
-but not limited to software source code, documentation source, and configuration
-files.
 
-"Object" form shall mean any form resulting from mechanical transformation or
-translation of a Source form, including but not limited to compiled object code,
-generated documentation, and conversions to other media types.
+    SPDX-License-Identifier:    BSD-3-Clause
 
-"Work" shall mean the work of authorship, whether in Source or Object form, made
-available under the License, as indicated by a copyright notice that is included
-in or attached to the work (an example is provided in the Appendix below).
-
-"Derivative Works" shall mean any work, whether in Source or Object form, that
-is based on (or derived from) the Work and for which the editorial revisions,
-annotations, elaborations, or other modifications represent, as a whole, an
-original work of authorship. For the purposes of this License, Derivative Works
-shall not include works that remain separable from, or merely link (or bind by
-name) to the interfaces of, the Work and Derivative Works thereof.
-
-"Contribution" shall mean any work of authorship, including the original version
-of the Work and any modifications or additions to that Work or Derivative Works
-thereof, that is intentionally submitted to Licensor for inclusion in the Work
-by the copyright owner or by an individual or Legal Entity authorized to submit
-on behalf of the copyright owner. For the purposes of this definition,
-"submitted" means any form of electronic, verbal, or written communication sent
-to the Licensor or its representatives, including but not limited to
-communication on electronic mailing lists, source code control systems, and
-issue tracking systems that are managed by, or on behalf of, the Licensor for
-the purpose of discussing and improving the Work, but excluding communication
-that is conspicuously marked or otherwise designated in writing by the copyright
-owner as "Not a Contribution."
-
-"Contributor" shall mean Licensor and any individual or Legal Entity on behalf
-of whom a Contribution has been received by Licensor and subsequently
-incorporated within the Work.
-
-2. Grant of Copyright License.
-
-Subject to the terms and conditions of this License, each Contributor hereby
-grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
-irrevocable copyright license to reproduce, prepare Derivative Works of,
-publicly display, publicly perform, sublicense, and distribute the Work and such
-Derivative Works in Source or Object form.
-
-3. Grant of Patent License.
-
-Subject to the terms and conditions of this License, each Contributor hereby
-grants to You a perpetual, worldwide, non-exclusive, no-charge, royalty-free,
-irrevocable (except as stated in this section) patent license to make, have
-made, use, offer to sell, sell, import, and otherwise transfer the Work, where
-such license applies only to those patent claims licensable by such Contributor
-that are necessarily infringed by their Contribution(s) alone or by combination
-of their Contribution(s) with the Work to which such Contribution(s) was
-submitted. If You institute patent litigation against any entity (including a
-cross-claim or counterclaim in a lawsuit) alleging that the Work or a
-Contribution incorporated within the Work constitutes direct or contributory
-patent infringement, then any patent licenses granted to You under this License
-for that Work shall terminate as of the date such litigation is filed.
-
-4. Redistribution.
-
-You may reproduce and distribute copies of the Work or Derivative Works thereof
-in any medium, with or without modifications, and in Source or Object form,
-provided that You meet the following conditions:
-
-You must give any other recipients of the Work or Derivative Works a copy of
-this License; and
-You must cause any modified files to carry prominent notices stating that You
-changed the files; and
-You must retain, in the Source form of any Derivative Works that You distribute,
-all copyright, patent, trademark, and attribution notices from the Source form
-of the Work, excluding those notices that do not pertain to any part of the
-Derivative Works; and
-If the Work includes a "NOTICE" text file as part of its distribution, then any
-Derivative Works that You distribute must include a readable copy of the
-attribution notices contained within such NOTICE file, excluding those notices
-that do not pertain to any part of the Derivative Works, in at least one of the
-following places: within a NOTICE text file distributed as part of the
-Derivative Works; within the Source form or documentation, if provided along
-with the Derivative Works; or, within a display generated by the Derivative
-Works, if and wherever such third-party notices normally appear. The contents of
-the NOTICE file are for informational purposes only and do not modify the
-License. You may add Your own attribution notices within Derivative Works that
-You distribute, alongside or as an addendum to the NOTICE text from the Work,
-provided that such additional attribution notices cannot be construed as
-modifying the License.
-You may add Your own copyright statement to Your modifications and may provide
-additional or different license terms and conditions for use, reproduction, or
-distribution of Your modifications, or for any such Derivative Works as a whole,
-provided Your use, reproduction, and distribution of the Work otherwise complies
-with the conditions stated in this License.
-
-5. Submission of Contributions.
-
-Unless You explicitly state otherwise, any Contribution intentionally submitted
-for inclusion in the Work by You to the Licensor shall be under the terms and
-conditions of this License, without any additional terms or conditions.
-Notwithstanding the above, nothing herein shall supersede or modify the terms of
-any separate license agreement you may have executed with Licensor regarding
-such Contributions.
-
-6. Trademarks.
-
-This License does not grant permission to use the trade names, trademarks,
-service marks, or product names of the Licensor, except as required for
-reasonable and customary use in describing the origin of the Work and
-reproducing the content of the NOTICE file.
-
-7. Disclaimer of Warranty.
-
-Unless required by applicable law or agreed to in writing, Licensor provides the
-Work (and each Contributor provides its Contributions) on an "AS IS" BASIS,
-WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied,
-including, without limitation, any warranties or conditions of TITLE,
-NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A PARTICULAR PURPOSE. You are
-solely responsible for determining the appropriateness of using or
-redistributing the Work and assume any risks associated with Your exercise of
-permissions under this License.
-
-8. Limitation of Liability.
-
-In no event and under no legal theory, whether in tort (including negligence),
-contract, or otherwise, unless required by applicable law (such as deliberate
-and grossly negligent acts) or agreed to in writing, shall any Contributor be
-liable to You for damages, including any direct, indirect, special, incidental,
-or consequential damages of any character arising as a result of this License or
-out of the use or inability to use the Work (including but not limited to
-damages for loss of goodwill, work stoppage, computer failure or malfunction, or
-any and all other commercial damages or losses), even if such Contributor has
-been advised of the possibility of such damages.
-
-9. Accepting Warranty or Additional Liability.
-
-While redistributing the Work or Derivative Works thereof, You may choose to
-offer, and charge a fee for, acceptance of support, warranty, indemnity, or
-other liability obligations and/or rights consistent with this License. However,
-in accepting such obligations, You may act only on Your own behalf and on Your
-sole responsibility, not on behalf of any other Contributor, and only if You
-agree to indemnify, defend, and hold each Contributor harmless for any liability
-incurred by, or claims asserted against, such Contributor by reason of your
-accepting any such warranty or additional liability.
+This enables machine processing of license information based on the SPDX
+License Identifiers that are here available: http://spdx.org/licenses/

--- a/Makefile
+++ b/Makefile
@@ -33,8 +33,9 @@ size: $(OBJ)
 	$(SIZE) -t $^
 
 .SUFFIXES:
-test: test_format test_dirs test_files test_seek test_truncate \
-	test_interspersed test_alloc test_paths test_orphan test_move test_corrupt
+test: test_format test_dirs test_files test_seek test_truncate test_entries \
+	test_interspersed test_alloc test_paths test_attrs \
+	test_orphan test_move test_corrupt
 test_%: tests/test_%.sh
 ifdef QUIET
 	@./$< | sed -n '/^[-=]/p'

--- a/emubd/lfs_emubd.c
+++ b/emubd/lfs_emubd.c
@@ -1,19 +1,8 @@
 /*
  * Block device emulated on standard files
  *
- * Copyright (c) 2017 ARM Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "emubd/lfs_emubd.h"
 

--- a/emubd/lfs_emubd.h
+++ b/emubd/lfs_emubd.h
@@ -1,19 +1,8 @@
 /*
  * Block device emulated on standard files
  *
- * Copyright (c) 2017 ARM Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef LFS_EMUBD_H
 #define LFS_EMUBD_H

--- a/lfs.c
+++ b/lfs.c
@@ -3183,3 +3183,19 @@ int lfs_fs_setattrs(lfs_t *lfs, const struct lfs_attr *attrs, int count) {
 
     return lfs_dir_setattrs(lfs, &dir, &entry, attrs, count);
 }
+
+static int lfs_fs_size_count(void *p, lfs_block_t block) {
+    lfs_size_t *size = p;
+    *size += 1;
+    return 0;
+}
+
+lfs_ssize_t lfs_fs_size(lfs_t *lfs) {
+    lfs_size_t size = 0;
+    int err = lfs_traverse(lfs, lfs_fs_size_count, &size);
+    if (err) {
+        return err;
+    }
+
+    return size;
+}

--- a/lfs.c
+++ b/lfs.c
@@ -683,7 +683,8 @@ static int lfs_dir_append(lfs_t *lfs, lfs_dir_t *dir,
         lfs_entry_t *entry, struct lfs_region *regions) {
     // check if we fit, if top bit is set we do not and move on
     while (true) {
-        if (dir->d.size + lfs_entry_size(entry) <= lfs->cfg->block_size) {
+        if ((0x7fffffff & dir->d.size) + lfs_entry_size(entry)
+                <= lfs->cfg->block_size) {
             entry->off = dir->d.size - 4;
             for (struct lfs_region *r = regions; r; r = r->next) {
                 r->off += entry->off;

--- a/lfs.c
+++ b/lfs.c
@@ -490,7 +490,8 @@ struct lfs_commit {
     lfs_off_t off;
 };
 
-static int lfs_commit(lfs_t *lfs, struct lfs_commit *c, const void *data, lfs_size_t size) {
+static int lfs_commit(lfs_t *lfs, struct lfs_commit *c,
+        const void *data, lfs_size_t size) {
     lfs_crc(&c->crc, data, size);
     int err = lfs_bd_prog(lfs, c->block, c->off, data, size);
     c->off += size;
@@ -500,46 +501,44 @@ static int lfs_commit(lfs_t *lfs, struct lfs_commit *c, const void *data, lfs_si
 struct lfs_region {
     lfs_off_t off;
     lfs_ssize_t diff;
-    int (*commit)(lfs_t *lfs, struct lfs_commit *c, const void *p);
+
+    int (*commit)(lfs_t *lfs, struct lfs_commit *c,
+            const void *data, lfs_size_t size);
     const void *data;
+    lfs_size_t size;
     struct lfs_region *next;
 };
 
-struct lfs_commit_mem {
-    const void *data;
-    lfs_size_t size;
-};
-
-static int lfs_commit_mem(lfs_t *lfs, struct lfs_commit *c, const void *p) {
-    const struct lfs_commit_mem *m = p;
-    return lfs_commit(lfs, c, m->data, m->size);
+static int lfs_commit_mem(lfs_t *lfs, struct lfs_commit *c,
+        const void *data, lfs_size_t size) {
+    return lfs_commit(lfs, c, data, size);
 }
 
 struct lfs_commit_disk {
     lfs_block_t block;
     lfs_off_t off;
-    lfs_size_t size;
     struct lfs_region *regions;
 };
 
-static int lfs_commit_disk(lfs_t *lfs, struct lfs_commit *c, const void *p) {
-    const struct lfs_commit_disk *u = p;
+static int lfs_commit_disk(lfs_t *lfs, struct lfs_commit *c,
+        const void *p, lfs_size_t size) {
+    const struct lfs_commit_disk *d = p;
 
-    struct lfs_region *r = u->regions;
+    struct lfs_region *r = d->regions;
     lfs_off_t off = 0;
     while (true) {
         if (r && r->off == off) {
             lfs_off_t orig = c->off;
-            int err = r->commit(lfs, c, r->data);
+            int err = r->commit(lfs, c, r->data, r->size);
             if (err) {
                 return err;
             }
 
             off += (c->off - orig) - r->diff;
             r = r->next;
-        } else if (off < u->size) {
+        } else if (off < size) {
             uint8_t data;
-            int err = lfs_bd_read(lfs, u->block, u->off + off, &data, 1);
+            int err = lfs_bd_read(lfs, d->block, d->off + off, &data, 1);
             if (err) {
                 return err;
             }
@@ -590,12 +589,11 @@ static int lfs_dir_commit(lfs_t *lfs, lfs_dir_t *dir,
 
             lfs_dir_tole32(&dir->d);
             err = lfs_commit_disk(lfs, &c, &(struct lfs_commit_disk){
-                    oldpair[1], 0, oldsize,
+                    oldpair[1], 0,
                     &(struct lfs_region){
                         0, 0,
-                        lfs_commit_mem, &(struct lfs_commit_mem){
-                            &dir->d, sizeof(dir->d)},
-                        regions}});
+                        lfs_commit_mem, &dir->d, sizeof(dir->d),
+                        regions}}, oldsize);
             lfs_dir_fromle32(&dir->d);
             if (err) {
                 if (err == LFS_ERR_CORRUPT) {
@@ -754,8 +752,7 @@ static int lfs_dir_update(lfs_t *lfs, lfs_dir_t *dir,
         int err = lfs_dir_commit(lfs, &olddir,
                 &(struct lfs_region){
                     oldoff, 0,
-                    lfs_commit_mem, &(struct lfs_commit_mem){
-                        &entry->d.type, 1}});
+                    lfs_commit_mem, &entry->d.type, 1});
         if (err) {
             return err;
         }
@@ -766,7 +763,7 @@ static int lfs_dir_update(lfs_t *lfs, lfs_dir_t *dir,
                 &(struct lfs_region){
                     0, +lfs_entry_size(entry),
                     lfs_commit_disk, &(struct lfs_commit_disk){
-                        olddir.pair[0], entry->off, oldsize, regions}});
+                        olddir.pair[0], entry->off, regions}, oldsize});
         if (err) {
             return err;
         }
@@ -775,8 +772,7 @@ static int lfs_dir_update(lfs_t *lfs, lfs_dir_t *dir,
         err = lfs_dir_commit(lfs, &olddir,
                 &(struct lfs_region){
                     oldoff, -oldsize,
-                    lfs_commit_mem, &(struct lfs_commit_mem){
-                        NULL, 0}});
+                    lfs_commit_mem, NULL, 0});
         if (err) {
             return err;
         }
@@ -829,8 +825,7 @@ static int lfs_dir_remove(lfs_t *lfs, lfs_dir_t *dir, lfs_entry_t *entry) {
     int err = lfs_dir_commit(lfs, dir,
             &(struct lfs_region){
                 entry->off, -lfs_entry_size(entry),
-                lfs_commit_mem, &(struct lfs_commit_mem){
-                    NULL, 0}});
+                lfs_commit_mem, NULL, 0});
     if (err) {
         return err;
     }
@@ -1053,12 +1048,10 @@ int lfs_mkdir(lfs_t *lfs, const char *path) {
     err = lfs_dir_append(lfs, &cwd, &entry,
             &(struct lfs_region){
                 0, +sizeof(entry.d),
-                lfs_commit_mem, &(struct lfs_commit_mem){
-                    &entry.d, sizeof(entry.d)},
+                lfs_commit_mem, &entry.d, sizeof(entry.d),
             &(struct lfs_region){
                 0, +entry.d.nlen,
-                lfs_commit_mem, &(struct lfs_commit_mem){
-                    path, entry.d.nlen}}});
+                lfs_commit_mem, path, entry.d.nlen}});
     if (err) {
         return err;
     }
@@ -1445,12 +1438,10 @@ int lfs_file_open(lfs_t *lfs, lfs_file_t *file,
         err = lfs_dir_append(lfs, &cwd, &entry,
                 &(struct lfs_region){
                     0, +sizeof(entry.d),
-                    lfs_commit_mem, &(struct lfs_commit_mem){
-                        &entry.d, sizeof(entry.d)},
+                    lfs_commit_mem, &entry.d, sizeof(entry.d),
                 &(struct lfs_region){
                     0, +entry.d.nlen,
-                    lfs_commit_mem, &(struct lfs_commit_mem){
-                        path, entry.d.nlen}}});
+                    lfs_commit_mem, path, entry.d.nlen}});
         if (err) {
             return err;
         }
@@ -1669,8 +1660,7 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
         err = lfs_dir_update(lfs, &cwd, &entry,
             &(struct lfs_region){
                 0, 0,
-                lfs_commit_mem, &(struct lfs_commit_mem){
-                    &entry.d, sizeof(entry.d)}});
+                lfs_commit_mem, &entry.d, sizeof(entry.d)});
         if (err) {
             return err;
         }
@@ -2095,8 +2085,7 @@ int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
     err = lfs_dir_update(lfs, &oldcwd, &oldentry,
             &(struct lfs_region){
                 0, 0,
-                lfs_commit_mem, &(struct lfs_commit_mem){
-                    &oldentry.d, sizeof(oldentry.d)}});
+                lfs_commit_mem, &oldentry.d, sizeof(oldentry.d)});
     if (err) {
         return err;
     }
@@ -2116,12 +2105,10 @@ int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
         err = lfs_dir_update(lfs, &newcwd, &newentry,
                 &(struct lfs_region){
                     0, 0,
-                    lfs_commit_mem, &(struct lfs_commit_mem){
-                        &newentry.d, sizeof(newentry.d)},
+                    lfs_commit_mem, &newentry.d, sizeof(newentry.d),
                 &(struct lfs_region){
                     sizeof(newentry.d), 0,
-                    lfs_commit_mem, &(struct lfs_commit_mem){
-                        newpath, newentry.d.nlen}}});
+                    lfs_commit_mem, newpath, newentry.d.nlen}});
         if (err) {
             return err;
         }
@@ -2129,12 +2116,10 @@ int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
         err = lfs_dir_append(lfs, &newcwd, &newentry,
                 &(struct lfs_region){
                     0, +sizeof(newentry.d),
-                    lfs_commit_mem, &(struct lfs_commit_mem){
-                        &newentry.d, sizeof(newentry.d)},
+                    lfs_commit_mem, &newentry.d, sizeof(newentry.d),
                 &(struct lfs_region){
                     0, +newentry.d.nlen,
-                    lfs_commit_mem, &(struct lfs_commit_mem){
-                        newpath, newentry.d.nlen}}});
+                    lfs_commit_mem, newpath, newentry.d.nlen}});
         if (err) {
             return err;
         }
@@ -2302,8 +2287,7 @@ int lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
     for (int i = 0; i < 2; i++) {
         err = lfs_dir_commit(lfs, &superdir, &(struct lfs_region){
                 sizeof(superdir.d), 0,
-                lfs_commit_mem, &(struct lfs_commit_mem){
-                    &superblock.d, sizeof(superblock.d)}});
+                lfs_commit_mem, &superblock.d, sizeof(superblock.d)});
         if (err && err != LFS_ERR_CORRUPT) {
             return err;
         }
@@ -2570,8 +2554,7 @@ static int lfs_relocate(lfs_t *lfs,
         int err = lfs_dir_update(lfs, &parent, &entry,
                 &(struct lfs_region){
                     0, 0,
-                    lfs_commit_mem, &(struct lfs_commit_mem){
-                        &entry.d, sizeof(entry.d)}});
+                    lfs_commit_mem, &entry.d, sizeof(entry.d)});
         if (err) {
             return err;
         }
@@ -2698,8 +2681,7 @@ int lfs_deorphan(lfs_t *lfs) {
                     err = lfs_dir_update(lfs, &cwd, &entry,
                             &(struct lfs_region){
                                 0, 0,
-                                lfs_commit_mem, &(struct lfs_commit_mem){
-                                    &entry.d, sizeof(entry.d)}});
+                                lfs_commit_mem, &entry.d, sizeof(entry.d)});
                     if (err) {
                         return err;
                     }

--- a/lfs.c
+++ b/lfs.c
@@ -24,7 +24,7 @@ static int lfs_cache_read(lfs_t *lfs, lfs_cache_t *rcache,
         const lfs_cache_t *pcache, lfs_block_t block,
         lfs_off_t off, void *buffer, lfs_size_t size) {
     uint8_t *data = buffer;
-    LFS_ASSERT(block < lfs->cfg->block_count);
+    LFS_ASSERT(block != 0xffffffff);
 
     while (size > 0) {
         if (pcache && block == pcache->block && off >= pcache->off &&
@@ -68,6 +68,7 @@ static int lfs_cache_read(lfs_t *lfs, lfs_cache_t *rcache,
         }
 
         // load to cache, first condition can no longer fail
+        LFS_ASSERT(block < lfs->cfg->block_count);
         rcache->block = block;
         rcache->off = off - (off % lfs->cfg->read_size);
         int err = lfs->cfg->read(lfs->cfg, rcache->block,
@@ -121,6 +122,7 @@ static int lfs_cache_crc(lfs_t *lfs, lfs_cache_t *rcache,
 static int lfs_cache_flush(lfs_t *lfs,
         lfs_cache_t *pcache, lfs_cache_t *rcache) {
     if (pcache->block != 0xffffffff) {
+        LFS_ASSERT(pcache->block < lfs->cfg->block_count);
         int err = lfs->cfg->prog(lfs->cfg, pcache->block,
                 pcache->off, pcache->buffer, lfs->cfg->prog_size);
         if (err) {
@@ -149,7 +151,7 @@ static int lfs_cache_prog(lfs_t *lfs, lfs_cache_t *pcache,
         lfs_cache_t *rcache, lfs_block_t block,
         lfs_off_t off, const void *buffer, lfs_size_t size) {
     const uint8_t *data = buffer;
-    LFS_ASSERT(block < lfs->cfg->block_count);
+    LFS_ASSERT(block != 0xffffffff);
 
     while (size > 0) {
         if (block == pcache->block && off >= pcache->off &&
@@ -181,6 +183,7 @@ static int lfs_cache_prog(lfs_t *lfs, lfs_cache_t *pcache,
         if (off % lfs->cfg->prog_size == 0 &&
                 size >= lfs->cfg->prog_size) {
             // bypass pcache?
+            LFS_ASSERT(block < lfs->cfg->block_count);
             lfs_size_t diff = size - (size % lfs->cfg->prog_size);
             int err = lfs->cfg->prog(lfs->cfg, block, off, data, diff);
             if (err) {
@@ -240,6 +243,7 @@ static int lfs_bd_crc(lfs_t *lfs, lfs_block_t block,
 }
 
 static int lfs_bd_erase(lfs_t *lfs, lfs_block_t block) {
+    LFS_ASSERT(block < lfs->cfg->block_count);
     return lfs->cfg->erase(lfs->cfg, block);
 }
 
@@ -851,7 +855,7 @@ static int lfs_dir_update(lfs_t *lfs, lfs_dir_t *dir,
 }
 
 static int lfs_dir_next(lfs_t *lfs, lfs_dir_t *dir, lfs_entry_t *entry) {
-    while (dir->off + sizeof(entry->d) > (0x7fffffff & dir->d.size)-4) {
+    while (dir->off >= (0x7fffffff & dir->d.size)-4) {
         if (!(0x80000000 & dir->d.size)) {
             entry->off = dir->off;
             return LFS_ERR_NOENT;
@@ -942,8 +946,8 @@ static int lfs_dir_find(lfs_t *lfs, lfs_dir_t *dir,
                 return err;
             }
 
-            if (((0x7f & entry->d.type) != (LFS_STRUCT_CTZ | LFS_TYPE_REG) &&
-                 (0x7f & entry->d.type) != (LFS_STRUCT_DIR | LFS_TYPE_DIR)) ||
+            if (((0xf & entry->d.type) != LFS_TYPE_REG &&
+                 (0xf & entry->d.type) != LFS_TYPE_DIR) ||
                 entry->d.nlen != pathlen) {
                 continue;
             }
@@ -1126,8 +1130,8 @@ int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
             return (err == LFS_ERR_NOENT) ? 0 : err;
         }
 
-        if ((0x7f & entry.d.type) != (LFS_STRUCT_CTZ | LFS_TYPE_REG) &&
-            (0x7f & entry.d.type) != (LFS_STRUCT_DIR | LFS_TYPE_DIR)) {
+        if ((0xf & entry.d.type) != LFS_TYPE_REG &&
+            (0xf & entry.d.type) != LFS_TYPE_DIR) {
             continue;
         }
 
@@ -1149,8 +1153,10 @@ int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
     }
 
     info->type = 0xf & entry.d.type;
-    if (info->type == LFS_TYPE_REG) {
+    if (entry.d.type == (LFS_STRUCT_CTZ | LFS_TYPE_REG)) {
         info->size = entry.d.u.file.size;
+    } else if (entry.d.type == (LFS_STRUCT_INLINE | LFS_TYPE_REG)) {
+        info->size = entry.d.elen;
     }
 
     int err = lfs_bd_read(lfs, dir->pair[0],
@@ -1424,18 +1430,16 @@ int lfs_file_open(lfs_t *lfs, lfs_file_t *file,
         }
 
         // create entry to remember name
-        entry.d.type = LFS_STRUCT_CTZ | LFS_TYPE_REG;
-        entry.d.elen = sizeof(entry.d) - 4;
+        entry.d.type = LFS_STRUCT_INLINE | LFS_TYPE_REG;
+        entry.d.elen = 0;
         entry.d.alen = 0;
         entry.d.nlen = strlen(path);
-        entry.d.u.file.head = 0xffffffff;
-        entry.d.u.file.size = 0;
         entry.size = 4 + entry.d.elen + entry.d.alen + entry.d.nlen;
 
         err = lfs_dir_append(lfs, &cwd, &entry,
                 &(struct lfs_region){
-                    0, +sizeof(entry.d),
-                    lfs_commit_mem, &entry.d, sizeof(entry.d),
+                    0, +4,
+                    lfs_commit_mem, &entry.d, 4,
                 &(struct lfs_region){
                     0, +entry.d.nlen,
                     lfs_commit_mem, path, entry.d.nlen}});
@@ -1478,6 +1482,22 @@ int lfs_file_open(lfs_t *lfs, lfs_file_t *file,
         file->cache.buffer = lfs_malloc(lfs->cfg->prog_size);
         if (!file->cache.buffer) {
             return LFS_ERR_NOMEM;
+        }
+    }
+
+    // load inline files
+    if ((0x70 & entry.d.type) == LFS_STRUCT_INLINE) {
+        file->head = 0xfffffffe;
+        file->size = entry.d.elen;
+        file->flags |= LFS_F_INLINE;
+        file->cache.block = file->head;
+        file->cache.off = 0;
+        err = lfs_bd_read(lfs, cwd.pair[0],
+                entry.off + 4,
+                file->cache.buffer, file->size);
+        if (err) {
+            lfs_free(file->cache.buffer);
+            return err;
         }
     }
 
@@ -1556,6 +1576,20 @@ relocate:
 }
 
 static int lfs_file_flush(lfs_t *lfs, lfs_file_t *file) {
+    if (file->flags & LFS_F_INLINE) {
+        // do nothing since we won't need the cache for anything else
+        if (file->flags & LFS_F_READING) {
+            file->flags &= ~LFS_F_READING;
+        }
+
+        if (file->flags & LFS_F_WRITING) {
+            file->flags &= ~LFS_F_WRITING;
+            file->flags |= LFS_F_DIRTY;
+        }
+
+        return 0;
+    }
+
     if (file->flags & LFS_F_READING) {
         // just drop read cache
         file->cache.block = 0xffffffff;
@@ -1642,6 +1676,7 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
             return err;
         }
 
+        // TODO entry read?
         lfs_entry_t entry = {.off = file->poff};
         err = lfs_bd_read(lfs, cwd.pair[0], entry.off,
                 &entry.d, sizeof(entry.d));
@@ -1649,19 +1684,35 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
         if (err) {
             return err;
         }
+        LFS_ASSERT((0xf & entry.d.type) == LFS_TYPE_REG);
+        entry.size = 4 + entry.d.elen + entry.d.alen + entry.d.nlen;
 
-        LFS_ASSERT(entry.d.type == (LFS_STRUCT_CTZ | LFS_TYPE_REG));
-        entry.d.u.file.head = file->head;
-        entry.d.u.file.size = file->size;
+        if (file->flags & LFS_F_INLINE) {
+            file->size = lfs_max(file->pos, file->size);
+            lfs_ssize_t diff = file->size - entry.d.elen;
+            entry.d.elen = file->size;
 
-        lfs_entry_tole32(&entry.d);
-        err = lfs_dir_update(lfs, &cwd, &entry,
-            &(struct lfs_region){
-                0, 0,
-                lfs_commit_mem, &entry.d, sizeof(entry.d)});
-        lfs_entry_fromle32(&entry.d);
-        if (err) {
-            return err;
+            err = lfs_dir_update(lfs, &cwd, &entry,
+                &(struct lfs_region){
+                    0, 0,
+                    lfs_commit_mem, &entry.d, 4,
+                &(struct lfs_region){
+                    4, diff,
+                    lfs_commit_mem, file->cache.buffer, file->size}});
+            if (err) {
+                return err;
+            }
+        } else {
+            entry.d.u.file.head = file->head;
+            entry.d.u.file.size = file->size;
+
+            err = lfs_dir_update(lfs, &cwd, &entry,
+                &(struct lfs_region){
+                    0, 0,
+                    lfs_commit_mem, &entry.d, sizeof(entry.d)});
+            if (err) {
+                return err;
+            }
         }
 
         file->flags &= ~LFS_F_DIRTY;
@@ -1699,11 +1750,16 @@ lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
         // check if we need a new block
         if (!(file->flags & LFS_F_READING) ||
                 file->off == lfs->cfg->block_size) {
-            int err = lfs_ctz_find(lfs, &file->cache, NULL,
-                    file->head, file->size,
-                    file->pos, &file->block, &file->off);
-            if (err) {
-                return err;
+            if (file->flags & LFS_F_INLINE) {
+                file->block = 0xfffffffe;
+                file->off = 0;
+            } else {
+                int err = lfs_ctz_find(lfs, &file->cache, NULL,
+                        file->head, file->size,
+                        file->pos, &file->block, &file->off);
+                if (err) {
+                    return err;
+                }
             }
 
             file->flags |= LFS_F_READING;
@@ -1761,31 +1817,42 @@ lfs_ssize_t lfs_file_write(lfs_t *lfs, lfs_file_t *file,
     }
 
     while (nsize > 0) {
+        //printf("pos %d\n", file->pos + nsize);
+        // TODO combine with block allocation?
+        if (file->pos + nsize >= LFS_INLINE_MAX) {
+            file->flags &= ~LFS_F_INLINE;
+        }
+
         // check if we need a new block
         if (!(file->flags & LFS_F_WRITING) ||
                 file->off == lfs->cfg->block_size) {
-            if (!(file->flags & LFS_F_WRITING) && file->pos > 0) {
-                // find out which block we're extending from
-                int err = lfs_ctz_find(lfs, &file->cache, NULL,
-                        file->head, file->size,
-                        file->pos-1, &file->block, &file->off);
+            if (file->flags & LFS_F_INLINE) {
+                file->block = 0xfffffffe;
+                file->off = 0;
+            } else {
+                if (!(file->flags & LFS_F_WRITING) && file->pos > 0) {
+                    // find out which block we're extending from
+                    int err = lfs_ctz_find(lfs, &file->cache, NULL,
+                            file->head, file->size,
+                            file->pos-1, &file->block, &file->off);
+                    if (err) {
+                        file->flags |= LFS_F_ERRED;
+                        return err;
+                    }
+
+                    // mark cache as dirty since we may have read data into it
+                    file->cache.block = 0xffffffff;
+                }
+
+                // extend file with new blocks
+                lfs_alloc_ack(lfs);
+                int err = lfs_ctz_extend(lfs, &lfs->rcache, &file->cache,
+                        file->block, file->pos,
+                        &file->block, &file->off);
                 if (err) {
                     file->flags |= LFS_F_ERRED;
                     return err;
                 }
-
-                // mark cache as dirty since we may have read data into it
-                file->cache.block = 0xffffffff;
-            }
-
-            // extend file with new blocks
-            lfs_alloc_ack(lfs);
-            int err = lfs_ctz_extend(lfs, &lfs->rcache, &file->cache,
-                    file->block, file->pos,
-                    &file->block, &file->off);
-            if (err) {
-                file->flags |= LFS_F_ERRED;
-                return err;
             }
 
             file->flags |= LFS_F_WRITING;

--- a/lfs.c
+++ b/lfs.c
@@ -1,19 +1,8 @@
 /*
  * The little filesystem
  *
- * Copyright (c) 2017 ARM Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "lfs.h"
 #include "lfs_util.h"

--- a/lfs.c
+++ b/lfs.c
@@ -1272,6 +1272,7 @@ int lfs_mkdir(lfs_t *lfs, const char *path) {
 
     cwd.d.tail[0] = dir.pair[0];
     cwd.d.tail[1] = dir.pair[1];
+    lfs_entry_tole32(&entry.d);
     err = lfs_dir_set(lfs, &cwd, &entry, (struct lfs_region[]){
             {LFS_FROM_MEM, 0, 0, &entry.d, sizeof(entry.d)},
             {LFS_FROM_MEM, 0, 0, path, nlen}}, 2);
@@ -1893,8 +1894,7 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
         }
 
         lfs_entry_t entry = {.off = file->pairoff};
-        err = lfs_dir_get(lfs, &cwd, entry.off, &entry.d, sizeof(entry.d));
-        lfs_entry_fromle32(&entry.d);
+        err = lfs_dir_get(lfs, &cwd, entry.off, &entry.d, 4);
         if (err) {
             return err;
         }
@@ -1912,6 +1912,7 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
             entry.d.u.file.head = file->head;
             entry.d.u.file.size = file->size;
 
+            lfs_entry_tole32(&entry.d);
             buffer = (const uint8_t *)&entry.d + 4;
             size = sizeof(entry.d) - 4;
         } else {
@@ -2249,7 +2250,7 @@ int lfs_file_getattrs(lfs_t *lfs, lfs_file_t *file,
         }
 
         lfs_entry_t entry = {.off = file->pairoff};
-        err = lfs_dir_get(lfs, &cwd, entry.off, &entry.d, sizeof(entry.d));
+        err = lfs_dir_get(lfs, &cwd, entry.off, &entry.d, 4);
         if (err) {
             return err;
         }
@@ -2293,7 +2294,7 @@ int lfs_file_setattrs(lfs_t *lfs, lfs_file_t *file,
         }
 
         lfs_entry_t entry = {.off = file->pairoff};
-        err = lfs_dir_get(lfs, &cwd, entry.off, &entry.d, sizeof(entry.d));
+        err = lfs_dir_get(lfs, &cwd, entry.off, &entry.d, 4);
         if (err) {
             return err;
         }
@@ -2740,7 +2741,7 @@ int lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
     }
 
     lfs_entry_t entry = {.off = sizeof(dir.d)};
-    err = lfs_dir_get(lfs, &dir, entry.off, &entry.d, sizeof(entry.d));
+    err = lfs_dir_get(lfs, &dir, entry.off, &entry.d, 4);
     if (err) {
         return err;
     }
@@ -3005,6 +3006,7 @@ static int lfs_relocate(lfs_t *lfs,
         // update disk, this creates a desync
         entry.d.u.dir[0] = newpair[0];
         entry.d.u.dir[1] = newpair[1];
+        lfs_entry_tole32(&entry.d);
         int err = lfs_dir_set(lfs, &parent, &entry, (struct lfs_region[]){
                 {LFS_FROM_MEM, 0, sizeof(entry.d),
                     &entry.d, sizeof(entry.d)}}, 1);
@@ -3133,8 +3135,7 @@ int lfs_deorphan(lfs_t *lfs) {
                             entry.d.u.dir[0], entry.d.u.dir[1]);
                     entry.d.type &= ~LFS_STRUCT_MOVED;
                     err = lfs_dir_set(lfs, &cwd, &entry, (struct lfs_region[]){
-                            {LFS_FROM_MEM, 0, sizeof(entry.d),
-                                &entry.d, sizeof(entry.d)}}, 1);
+                            {LFS_FROM_MEM, 0, 1, &entry.d, 1}}, 1);
                     if (err) {
                         return err;
                     }
@@ -3158,7 +3159,7 @@ int lfs_fs_getattrs(lfs_t *lfs, const struct lfs_attr *attrs, int count) {
     }
 
     lfs_entry_t entry = {.off = sizeof(dir.d)};
-    err = lfs_dir_get(lfs, &dir, entry.off, &entry.d, sizeof(entry.d));
+    err = lfs_dir_get(lfs, &dir, entry.off, &entry.d, 4);
     if (err) {
         return err;
     }
@@ -3175,7 +3176,7 @@ int lfs_fs_setattrs(lfs_t *lfs, const struct lfs_attr *attrs, int count) {
     }
 
     lfs_entry_t entry = {.off = sizeof(dir.d)};
-    err = lfs_dir_get(lfs, &dir, entry.off, &entry.d, sizeof(entry.d));
+    err = lfs_dir_get(lfs, &dir, entry.off, &entry.d, 4);
     if (err) {
         return err;
     }

--- a/lfs.c
+++ b/lfs.c
@@ -722,7 +722,6 @@ relocate:
     return 0;
 }
 
-// TODO zeros?
 static int lfs_dir_get(lfs_t *lfs, const lfs_dir_t *dir,
         lfs_off_t off, void *buffer, lfs_size_t size) {
     return lfs_bd_read(lfs, dir->pair[0], off, buffer, size);
@@ -1180,8 +1179,6 @@ int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
         break;
     }
 
-    // TODO common info constructor?
-    // TODO also used in lfs_stat
     info->type = 0xf & entry.d.type;
     if (entry.d.type == (LFS_STRUCT_CTZ | LFS_TYPE_REG)) {
         info->size = entry.d.u.file.size;
@@ -1707,7 +1704,6 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
             return err;
         }
 
-        // TODO entry read function?
         lfs_entry_t entry = {.off = file->poff};
         err = lfs_dir_get(lfs, &cwd, entry.off, &entry.d, sizeof(entry.d));
         lfs_entry_fromle32(&entry.d);
@@ -1778,7 +1774,6 @@ lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
     nsize = size;
 
     while (nsize > 0) {
-        // TODO can this be collapsed?
         // check if we need a new block
         if (!(file->flags & LFS_F_READING) ||
                 file->off == lfs->cfg->block_size) {
@@ -1848,12 +1843,9 @@ lfs_ssize_t lfs_file_write(lfs_t *lfs, lfs_file_t *file,
         }
     }
 
-    // TODO combine with block allocation?
-    // TODO need to move out if no longer fits in block also
-    // TODO store INLINE_MAX in superblock?
-    // TODO what if inline files is > block size (ie 128)
     if ((file->flags & LFS_F_INLINE) &&
             file->pos + nsize >= file->inline_size) {
+        // inline file doesn't fit anymore
         file->block = 0xfffffffe;
         file->off = file->pos;
 
@@ -1869,9 +1861,6 @@ lfs_ssize_t lfs_file_write(lfs_t *lfs, lfs_file_t *file,
     }
 
     while (nsize > 0) {
-        // TODO can this be collapsed?
-        // TODO can we reduce this now that block 0 is never allocated?
-        // TODO actually, how does this behave if inline max == 0?
         // check if we need a new block
         if (!(file->flags & LFS_F_WRITING) ||
                 file->off == lfs->cfg->block_size) {
@@ -1969,7 +1958,6 @@ lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
     return file->pos;
 }
 
-// TODO handle inlining?
 int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     if ((file->flags & 3) == LFS_O_RDONLY) {
         return LFS_ERR_BADF;

--- a/lfs.c
+++ b/lfs.c
@@ -381,6 +381,26 @@ static void lfs_superblock_tole32(struct lfs_disk_superblock *d) {
     d->name_size   = lfs_tole32(d->name_size);
 }
 
+/// Other struct functions ///
+static inline lfs_size_t lfs_entry_elen(const lfs_entry_t *entry) {
+    return (lfs_size_t)(entry->d.elen) |
+        ((lfs_size_t)(entry->d.alen & 0xc0) << 2);
+}
+
+static inline lfs_size_t lfs_entry_alen(const lfs_entry_t *entry) {
+    return entry->d.alen & 0x3f;
+}
+
+static inline lfs_size_t lfs_entry_nlen(const lfs_entry_t *entry) {
+    return entry->d.nlen;
+}
+
+static inline lfs_size_t lfs_entry_size(const lfs_entry_t *entry) {
+    return 4 + lfs_entry_elen(entry) +
+            lfs_entry_alen(entry) +
+            lfs_entry_nlen(entry);
+}
+
 
 /// Metadata pair and directory operations ///
 static inline void lfs_pairswap(lfs_block_t pair[2]) {
@@ -573,7 +593,7 @@ static int lfs_commit_region(lfs_t *lfs,
     return 0;
 }
 
-static int lfs_dif_commit(lfs_t *lfs, lfs_dir_t *dir,
+static int lfs_dir_commit(lfs_t *lfs, lfs_dir_t *dir,
         const struct lfs_region *regions, int count) {
     // state for copying over
     const lfs_block_t oldpair[2] = {dir->pair[1], dir->pair[0]};
@@ -733,7 +753,7 @@ static int lfs_dir_set(lfs_t *lfs, lfs_dir_t *dir, lfs_entry_t *entry,
             }
 
             type |= LFS_STRUCT_MOVED;
-            err = lfs_dif_commit(lfs, &olddir, (struct lfs_region[]){
+            err = lfs_dir_commit(lfs, &olddir, (struct lfs_region[]){
                         {LFS_FROM_MEM, oldoff, &type, 1},
                         {LFS_FROM_DROP, oldoff, NULL, -1}}, 2);
             if (err) {
@@ -769,7 +789,7 @@ static int lfs_dir_set(lfs_t *lfs, lfs_dir_t *dir, lfs_entry_t *entry,
         // writing out new entry
         entry->off = dir->d.size - 4;
         entry->size += diff;
-        int err = lfs_dif_commit(lfs, dir, (struct lfs_region[]){
+        int err = lfs_dir_commit(lfs, dir, (struct lfs_region[]){
                 {LFS_FROM_REGION, entry->off, &(struct lfs_region_region){
                     olddir.pair[0], oldoff,
                     regions, count}, entry->size}}, 1);
@@ -783,7 +803,7 @@ static int lfs_dir_set(lfs_t *lfs, lfs_dir_t *dir, lfs_entry_t *entry,
             pdir.d.tail[0] = dir->pair[0];
             pdir.d.tail[1] = dir->pair[1];
 
-            err = lfs_dif_commit(lfs, &pdir, NULL, 0);
+            err = lfs_dir_commit(lfs, &pdir, NULL, 0);
             if (err) {
                 return err;
             }
@@ -818,7 +838,7 @@ static int lfs_dir_set(lfs_t *lfs, lfs_dir_t *dir, lfs_entry_t *entry,
             pdir.d.size &= dir->d.size | 0x7fffffff;
             pdir.d.tail[0] = dir->d.tail[0];
             pdir.d.tail[1] = dir->d.tail[1];
-            int err = lfs_dif_commit(lfs, &pdir, NULL, 0);
+            int err = lfs_dir_commit(lfs, &pdir, NULL, 0);
             if (err) {
                 return err;
             }
@@ -830,7 +850,7 @@ static int lfs_dir_set(lfs_t *lfs, lfs_dir_t *dir, lfs_entry_t *entry,
         regions[i].off += entry->off;
     }
 
-    int err = lfs_dif_commit(lfs, dir, regions, count);
+    int err = lfs_dir_commit(lfs, dir, regions, count);
     if (err) {
         return err;
     }
@@ -885,7 +905,7 @@ static int lfs_dir_next(lfs_t *lfs, lfs_dir_t *dir, lfs_entry_t *entry) {
     }
 
     entry->off = dir->off;
-    entry->size = 4 + entry->d.elen + entry->d.alen + entry->d.nlen;
+    entry->size = lfs_entry_size(entry);
     dir->off += entry->size;
     dir->pos += entry->size;
     return 0;
@@ -1041,7 +1061,7 @@ int lfs_mkdir(lfs_t *lfs, const char *path) {
     dir.d.tail[0] = cwd.d.tail[0];
     dir.d.tail[1] = cwd.d.tail[1];
 
-    err = lfs_dif_commit(lfs, &dir, NULL, 0);
+    err = lfs_dir_commit(lfs, &dir, NULL, 0);
     if (err) {
         return err;
     }
@@ -1166,7 +1186,7 @@ int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
     if (entry.d.type == (LFS_STRUCT_CTZ | LFS_TYPE_REG)) {
         info->size = entry.d.u.file.size;
     } else if (entry.d.type == (LFS_STRUCT_INLINE | LFS_TYPE_REG)) {
-        info->size = entry.d.elen;
+        info->size = lfs_entry_elen(&entry);
     }
 
     int err = lfs_dir_get(lfs, dir,
@@ -1480,29 +1500,22 @@ int lfs_file_open(lfs_t *lfs, lfs_file_t *file,
         }
     }
 
-    // TODO combine these below?
     // setup file struct
     file->pair[0] = cwd.pair[0];
     file->pair[1] = cwd.pair[1];
     file->poff = entry.off;
-    file->head = entry.d.u.file.head;
-    file->size = entry.d.u.file.size;
     file->flags = flags;
     file->pos = 0;
 
-    if (flags & LFS_O_TRUNC) {
-        if (file->size != 0) {
-            file->flags |= LFS_F_DIRTY;
-        }
+    // calculate max inline size based on the size of the entry
+    file->inline_size = lfs_min(lfs->inline_size,
+        lfs->cfg->block_size - (sizeof(cwd.d)+4) -
+        (lfs_entry_size(&entry) - lfs_entry_elen(&entry)));
 
-        entry.d.type = LFS_STRUCT_INLINE | LFS_TYPE_REG;
-        entry.d.elen = 0;
-    }
-
-    // load inline files
     if ((0x70 & entry.d.type) == LFS_STRUCT_INLINE) {
+        // load inline files
         file->head = 0xfffffffe;
-        file->size = entry.d.elen;
+        file->size = lfs_entry_elen(&entry);
         file->flags |= LFS_F_INLINE;
         file->cache.block = file->head;
         file->cache.off = 0;
@@ -1513,6 +1526,23 @@ int lfs_file_open(lfs_t *lfs, lfs_file_t *file,
             lfs_free(file->cache.buffer);
             return err;
         }
+    } else {
+        // use ctz list from entry
+        file->head = entry.d.u.file.head;
+        file->size = entry.d.u.file.size;
+    }
+
+    // truncate if requested
+    if (flags & LFS_O_TRUNC) {
+        if (file->size != 0) {
+            file->flags |= LFS_F_DIRTY;
+        }
+
+        file->head = 0xfffffffe;
+        file->size = 0;
+        file->flags |= LFS_F_INLINE;
+        file->cache.block = file->head;
+        file->cache.off = 0;
     }
 
     // add to list of files
@@ -1686,8 +1716,8 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
         }
 
         LFS_ASSERT((0xf & entry.d.type) == LFS_TYPE_REG);
-        lfs_size_t oldlen = entry.d.elen;
-        entry.size = 4 + entry.d.elen + entry.d.alen + entry.d.nlen;
+        lfs_size_t oldlen = lfs_entry_elen(&entry);
+        entry.size = lfs_entry_size(&entry);
 
         // either update the references or inline the whole file
         if (!(file->flags & LFS_F_INLINE)) {
@@ -1704,7 +1734,8 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
             }
         } else {
             entry.d.type = LFS_STRUCT_INLINE | LFS_TYPE_REG;
-            entry.d.elen = file->size;
+            entry.d.elen = file->size & 0xff;
+            entry.d.alen = (entry.d.alen & 0x3f) | ((file->size >> 2) & 0xc0);
 
             err = lfs_dir_set(lfs, &cwd, &entry, (struct lfs_region[]){
                     {LFS_FROM_MEM, 0, &entry.d, 4},
@@ -1822,7 +1853,7 @@ lfs_ssize_t lfs_file_write(lfs_t *lfs, lfs_file_t *file,
     // TODO store INLINE_MAX in superblock?
     // TODO what if inline files is > block size (ie 128)
     if ((file->flags & LFS_F_INLINE) &&
-            file->pos + nsize >= lfs->inline_size) {
+            file->pos + nsize >= file->inline_size) {
         file->block = 0xfffffffe;
         file->off = file->pos;
 
@@ -2034,7 +2065,7 @@ int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info) {
     if (entry.d.type == (LFS_STRUCT_CTZ | LFS_TYPE_REG)) {
         info->size = entry.d.u.file.size;
     } else if (entry.d.type == (LFS_STRUCT_INLINE | LFS_TYPE_REG)) {
-        info->size = entry.d.elen;
+        info->size = lfs_entry_elen(&entry);
     }
 
     if (lfs_paircmp(entry.d.u.dir, lfs->root) == 0) {
@@ -2103,7 +2134,7 @@ int lfs_remove(lfs_t *lfs, const char *path) {
         cwd.d.tail[0] = dir.d.tail[0];
         cwd.d.tail[1] = dir.d.tail[1];
 
-        err = lfs_dif_commit(lfs, &cwd, NULL, 0);
+        err = lfs_dir_commit(lfs, &cwd, NULL, 0);
         if (err) {
             return err;
         }
@@ -2234,7 +2265,7 @@ int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath) {
         newcwd.d.tail[0] = dir.d.tail[0];
         newcwd.d.tail[1] = dir.d.tail[1];
 
-        err = lfs_dif_commit(lfs, &newcwd, NULL, 0);
+        err = lfs_dir_commit(lfs, &newcwd, NULL, 0);
         if (err) {
             return err;
         }
@@ -2364,7 +2395,7 @@ int lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
         return err;
     }
 
-    err = lfs_dif_commit(lfs, &root, NULL, 0);
+    err = lfs_dir_commit(lfs, &root, NULL, 0);
     if (err) {
         return err;
     }
@@ -2446,14 +2477,14 @@ int lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
     memset(&superblock.d, 0, sizeof(superblock.d));
     err = lfs_dir_get(lfs, &dir,
             sizeof(dir.d)+4, &superblock.d,
-            lfs_min(sizeof(superblock.d), entry.d.elen));
+            lfs_min(sizeof(superblock.d), lfs_entry_elen(&entry)));
     lfs_superblock_fromle32(&superblock.d);
     if (err) {
         return err;
     }
 
     err = lfs_dir_get(lfs, &dir,
-            sizeof(dir.d)+4+entry.d.elen+entry.d.alen, magic,
+            sizeof(dir.d)+lfs_entry_size(&entry)-entry.d.nlen, magic,
             lfs_min(sizeof(magic), entry.d.nlen));
     if (err) {
         return err;
@@ -2546,7 +2577,7 @@ int lfs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data) {
                 return err;
             }
 
-            dir.off += 4 + entry.d.elen + entry.d.alen + entry.d.nlen;
+            dir.off += lfs_entry_size(&entry);
             if ((0x70 & entry.d.type) == LFS_STRUCT_CTZ) {
                 err = lfs_ctz_traverse(lfs, &lfs->rcache, NULL,
                         entry.d.u.file.head, entry.d.u.file.size, cb, data);
@@ -2730,7 +2761,7 @@ static int lfs_relocate(lfs_t *lfs,
         parent.d.tail[0] = newpair[0];
         parent.d.tail[1] = newpair[1];
 
-        return lfs_dif_commit(lfs, &parent, NULL, 0);
+        return lfs_dir_commit(lfs, &parent, NULL, 0);
     }
 
     // couldn't find dir, must be new
@@ -2772,7 +2803,7 @@ int lfs_deorphan(lfs_t *lfs) {
                 pdir.d.tail[0] = cwd.d.tail[0];
                 pdir.d.tail[1] = cwd.d.tail[1];
 
-                err = lfs_dif_commit(lfs, &pdir, NULL, 0);
+                err = lfs_dir_commit(lfs, &pdir, NULL, 0);
                 if (err) {
                     return err;
                 }
@@ -2788,7 +2819,7 @@ int lfs_deorphan(lfs_t *lfs) {
                 pdir.d.tail[0] = entry.d.u.dir[0];
                 pdir.d.tail[1] = entry.d.u.dir[1];
 
-                err = lfs_dif_commit(lfs, &pdir, NULL, 0);
+                err = lfs_dir_commit(lfs, &pdir, NULL, 0);
                 if (err) {
                     return err;
                 }

--- a/lfs.h
+++ b/lfs.h
@@ -74,9 +74,15 @@ enum lfs_error {
 
 // File types
 enum lfs_type {
-    LFS_TYPE_REG        = 0x11,
-    LFS_TYPE_DIR        = 0x22,
-    LFS_TYPE_SUPERBLOCK = 0x2e,
+    // file type
+    LFS_TYPE_REG        = 0x01,
+    LFS_TYPE_DIR        = 0x02,
+    LFS_TYPE_SUPERBLOCK = 0x0e,
+
+    // on disk structure
+    LFS_STRUCT_CTZ      = 0x10,
+    LFS_STRUCT_DIR      = 0x20,
+    LFS_STRUCT_MOVED    = 0x80,
 };
 
 // File open flags

--- a/lfs.h
+++ b/lfs.h
@@ -590,6 +590,14 @@ int lfs_fs_getattrs(lfs_t *lfs, const struct lfs_attr *attrs, int count);
 // Returns a negative error code on failure.
 int lfs_fs_setattrs(lfs_t *lfs, const struct lfs_attr *attrs, int count);
 
+// Finds the current size of the filesystem
+//
+// Note: Result is best effort. If files share COW structures, the returned
+// size may be larger than the filesystem actually is.
+//
+// Returns the number of allocated blocks, or a negative error code on failure.
+lfs_ssize_t lfs_fs_size(lfs_t *lfs);
+
 
 /// Miscellaneous littlefs specific operations ///
 

--- a/lfs.h
+++ b/lfs.h
@@ -257,15 +257,10 @@ typedef struct lfs_dir {
 
 typedef struct lfs_superblock {
     struct lfs_disk_superblock {
-        uint8_t type;
-        uint8_t elen;
-        uint8_t alen;
-        uint8_t nlen;
         lfs_block_t root[2];
         uint32_t block_size;
         uint32_t block_count;
         uint32_t version;
-        char magic[8];
     } d;
 } lfs_superblock_t;
 

--- a/lfs.h
+++ b/lfs.h
@@ -196,6 +196,7 @@ struct lfs_info {
 /// littlefs data structures ///
 typedef struct lfs_entry {
     lfs_off_t off;
+    lfs_size_t size;
 
     struct lfs_disk_entry {
         uint8_t type;
@@ -249,8 +250,6 @@ typedef struct lfs_dir {
 } lfs_dir_t;
 
 typedef struct lfs_superblock {
-    lfs_off_t off;
-
     struct lfs_disk_superblock {
         uint8_t type;
         uint8_t elen;

--- a/lfs.h
+++ b/lfs.h
@@ -89,6 +89,8 @@ enum lfs_error {
     LFS_ERR_NOSPC       = -28,  // No space left on device
     LFS_ERR_NOMEM       = -12,  // No more memory available
     LFS_ERR_NAMETOOLONG = -36,  // File name too long
+    LFS_ERR_NODATA      = -61,  // No data/attr available
+    LFS_ERR_RANGE       = -34,  // Result not representable
 };
 
 // File types
@@ -253,6 +255,13 @@ typedef struct lfs_entry {
     } d;
 } lfs_entry_t;
 
+typedef struct lfs_attr {
+    struct lfs_disk_attr {
+        uint8_t type;
+        uint8_t len;
+    } d;
+} lfs_attr_t;
+
 typedef struct lfs_cache {
     lfs_block_t block;
     lfs_off_t off;
@@ -378,6 +387,29 @@ int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath);
 // Fills out the info structure, based on the specified file or directory.
 // Returns a negative error code on failure.
 int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info);
+
+// Get a custom attribute
+//
+// Attributes are identified by an 8-bit type and are limited to at
+// most LFS_ATTRS_SIZE bytes.
+// Returns the size of the attribute, or a negative error code on failure.
+int lfs_getattr(lfs_t *lfs, const char *path,
+        uint8_t type, void *buffer, lfs_size_t size);
+
+// Set a custom attribute
+//
+// Attributes are identified by an 8-bit type and are limited to at
+// most LFS_ATTRS_SIZE bytes.
+// Returns a negative error code on failure.
+int lfs_setattr(lfs_t *lfs, const char *path,
+        uint8_t type, const void *buffer, lfs_size_t size);
+
+// Remove a custom attribute
+//
+// Attributes are identified by an 8-bit type and are limited to at
+// most LFS_ATTRS_SIZE bytes.
+// Returns a negative error code on failure.
+int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type);
 
 
 /// File operations ///

--- a/lfs.h
+++ b/lfs.h
@@ -55,6 +55,10 @@ typedef uint32_t lfs_block_t;
 #define LFS_NAME_MAX 255
 #endif
 
+#ifndef LFS_INLINE_MAX
+#define LFS_INLINE_MAX 255
+#endif
+
 // Possible error codes, these are negative to allow
 // valid positive return values
 enum lfs_error {
@@ -82,25 +86,27 @@ enum lfs_type {
     // on disk structure
     LFS_STRUCT_CTZ      = 0x10,
     LFS_STRUCT_DIR      = 0x20,
+    LFS_STRUCT_INLINE   = 0x30,
     LFS_STRUCT_MOVED    = 0x80,
 };
 
 // File open flags
 enum lfs_open_flags {
     // open flags
-    LFS_O_RDONLY = 1,        // Open a file as read only
-    LFS_O_WRONLY = 2,        // Open a file as write only
-    LFS_O_RDWR   = 3,        // Open a file as read and write
-    LFS_O_CREAT  = 0x0100,   // Create a file if it does not exist
-    LFS_O_EXCL   = 0x0200,   // Fail if a file already exists
-    LFS_O_TRUNC  = 0x0400,   // Truncate the existing file to zero size
-    LFS_O_APPEND = 0x0800,   // Move to end of file on every write
+    LFS_O_RDONLY = 1,         // Open a file as read only
+    LFS_O_WRONLY = 2,         // Open a file as write only
+    LFS_O_RDWR   = 3,         // Open a file as read and write
+    LFS_O_CREAT  = 0x0100,    // Create a file if it does not exist
+    LFS_O_EXCL   = 0x0200,    // Fail if a file already exists
+    LFS_O_TRUNC  = 0x0400,    // Truncate the existing file to zero size
+    LFS_O_APPEND = 0x0800,    // Move to end of file on every write
 
     // internally used flags
-    LFS_F_DIRTY   = 0x10000, // File does not match storage
-    LFS_F_WRITING = 0x20000, // File has been written since last flush
-    LFS_F_READING = 0x40000, // File has been read since last flush
-    LFS_F_ERRED   = 0x80000, // An error occured during write
+    LFS_F_DIRTY   = 0x10000,  // File does not match storage
+    LFS_F_WRITING = 0x20000,  // File has been written since last flush
+    LFS_F_READING = 0x40000,  // File has been read since last flush
+    LFS_F_ERRED   = 0x80000,  // An error occured during write
+    LFS_F_INLINE  = 0x100000, // Currently inlined in directory entry
 };
 
 // File seek flags

--- a/lfs.h
+++ b/lfs.h
@@ -27,14 +27,14 @@
 // Software library version
 // Major (top-nibble), incremented on backwards incompatible changes
 // Minor (bottom-nibble), incremented on feature additions
-#define LFS_VERSION 0x00010003
+#define LFS_VERSION 0x00010004
 #define LFS_VERSION_MAJOR (0xffff & (LFS_VERSION >> 16))
 #define LFS_VERSION_MINOR (0xffff & (LFS_VERSION >>  0))
 
 // Version of On-disk data structures
 // Major (top-nibble), incremented on backwards incompatible changes
 // Minor (bottom-nibble), incremented on feature additions
-#define LFS_DISK_VERSION 0x00010001
+#define LFS_DISK_VERSION 0x00010002
 #define LFS_DISK_VERSION_MAJOR (0xffff & (LFS_DISK_VERSION >> 16))
 #define LFS_DISK_VERSION_MINOR (0xffff & (LFS_DISK_VERSION >>  0))
 
@@ -50,17 +50,25 @@ typedef int32_t  lfs_soff_t;
 
 typedef uint32_t lfs_block_t;
 
-// Maximum inline file size in bytes
+// Maximum inline file size in bytes. Large inline files require a larger
+// read and prog cache, but if a file can be inline it does not need its own
+// data block. LFS_ATTRS_MAX + LFS_INLINE_MAX must be <= 0xffff. Stored in
+// superblock and must be respected by other littlefs drivers.
 #ifndef LFS_INLINE_MAX
 #define LFS_INLINE_MAX 0x3ff
 #endif
 
-// Maximum size of all attributes per file in bytes
+// Maximum size of all attributes per file in bytes, may be redefined but a
+// a smaller LFS_ATTRS_MAX has no benefit. LFS_ATTRS_MAX + LFS_INLINE_MAX
+// must be <= 0xffff. Stored in superblock and must be respected by other
+// littlefs drivers.
 #ifndef LFS_ATTRS_MAX
 #define LFS_ATTRS_MAX 0x3f
 #endif
 
-// Max name size in bytes
+// Max name size in bytes, may be redefined to reduce the size of the
+// info struct. Stored in superblock and must be respected by other
+// littlefs drivers.
 #ifndef LFS_NAME_MAX
 #define LFS_NAME_MAX 0xff
 #endif
@@ -191,11 +199,23 @@ struct lfs_config {
     // If enabled, only one file may be opened at a time.
     void *file_buffer;
 
-    // Optional,
+    // Optional upper limit on inlined files in bytes. Large inline files
+    // require a larger read and prog cache, but if a file can be inlined it
+    // does not need its own data block. Must be smaller than the read size
+    // and prog size. Defaults to min(LFS_INLINE_MAX, read_size) when zero.
+    // Stored in superblock and must be respected by other littlefs drivers.
     lfs_size_t inline_size;
-    // Optional,
+
+    // Optional upper limit on attributes per file in bytes. No downside for
+    // larger attributes size but must be less than LFS_ATTRS_MAX. Defaults to
+    // LFS_ATTRS_MAX when zero.Stored in superblock and must be respected by
+    // other littlefs drivers.
     lfs_size_t attrs_size;
-    // Optional,
+
+    // Optional upper limit on length of file names in bytes. No downside for
+    // larger names except the size of the info struct which is controlled by
+    // the LFS_NAME_MAX define. Defaults to LFS_NAME_MAX when zero. Stored in
+    // superblock and must be respected by other littlefs drivers.
     lfs_size_t name_size;
 };
 

--- a/lfs.h
+++ b/lfs.h
@@ -50,30 +50,37 @@ typedef int32_t  lfs_soff_t;
 
 typedef uint32_t lfs_block_t;
 
+// Maximum inline file size in bytes
+#ifndef LFS_INLINE_MAX
+#define LFS_INLINE_MAX 255
+#endif
+
+// Maximum size of all attributes per file in bytes
+#ifndef LFS_ATTRS_MAX
+#define LFS_ATTRS_MAX 255
+#endif
+
 // Max name size in bytes
 #ifndef LFS_NAME_MAX
 #define LFS_NAME_MAX 255
 #endif
 
-#ifndef LFS_INLINE_MAX
-#define LFS_INLINE_MAX 255
-#endif
-
 // Possible error codes, these are negative to allow
 // valid positive return values
 enum lfs_error {
-    LFS_ERR_OK       = 0,    // No error
-    LFS_ERR_IO       = -5,   // Error during device operation
-    LFS_ERR_CORRUPT  = -52,  // Corrupted
-    LFS_ERR_NOENT    = -2,   // No directory entry
-    LFS_ERR_EXIST    = -17,  // Entry already exists
-    LFS_ERR_NOTDIR   = -20,  // Entry is not a dir
-    LFS_ERR_ISDIR    = -21,  // Entry is a dir
-    LFS_ERR_NOTEMPTY = -39,  // Dir is not empty
-    LFS_ERR_BADF     = -9,   // Bad file number
-    LFS_ERR_INVAL    = -22,  // Invalid parameter
-    LFS_ERR_NOSPC    = -28,  // No space left on device
-    LFS_ERR_NOMEM    = -12,  // No more memory available
+    LFS_ERR_OK          = 0,    // No error
+    LFS_ERR_IO          = -5,   // Error during device operation
+    LFS_ERR_CORRUPT     = -52,  // Corrupted
+    LFS_ERR_NOENT       = -2,   // No directory entry
+    LFS_ERR_EXIST       = -17,  // Entry already exists
+    LFS_ERR_NOTDIR      = -20,  // Entry is not a dir
+    LFS_ERR_ISDIR       = -21,  // Entry is a dir
+    LFS_ERR_NOTEMPTY    = -39,  // Dir is not empty
+    LFS_ERR_BADF        = -9,   // Bad file number
+    LFS_ERR_INVAL       = -22,  // Invalid parameter
+    LFS_ERR_NOSPC       = -28,  // No space left on device
+    LFS_ERR_NOMEM       = -12,  // No more memory available
+    LFS_ERR_NAMETOOLONG = -36,  // File name too long
 };
 
 // File types
@@ -102,10 +109,10 @@ enum lfs_open_flags {
     LFS_O_APPEND = 0x0800,    // Move to end of file on every write
 
     // internally used flags
-    LFS_F_DIRTY   = 0x10000,  // File does not match storage
-    LFS_F_WRITING = 0x20000,  // File has been written since last flush
-    LFS_F_READING = 0x40000,  // File has been read since last flush
-    LFS_F_ERRED   = 0x80000,  // An error occured during write
+    LFS_F_DIRTY   = 0x010000, // File does not match storage
+    LFS_F_WRITING = 0x020000, // File has been written since last flush
+    LFS_F_READING = 0x040000, // File has been read since last flush
+    LFS_F_ERRED   = 0x080000, // An error occured during write
     LFS_F_INLINE  = 0x100000, // Currently inlined in directory entry
 };
 
@@ -183,6 +190,13 @@ struct lfs_config {
     // Optional, statically allocated buffer for files. Must be program sized.
     // If enabled, only one file may be opened at a time.
     void *file_buffer;
+
+    // Optional,
+    lfs_size_t inline_size;
+    // Optional,
+    lfs_size_t attrs_size;
+    // Optional,
+    lfs_size_t name_size;
 };
 
 
@@ -258,9 +272,14 @@ typedef struct lfs_dir {
 typedef struct lfs_superblock {
     struct lfs_disk_superblock {
         lfs_block_t root[2];
-        uint32_t block_size;
-        uint32_t block_count;
+
+        lfs_size_t block_size;
+        lfs_size_t block_count;
         uint32_t version;
+
+        lfs_size_t inline_size;
+        lfs_size_t attrs_size;
+        lfs_size_t name_size;
     } d;
 } lfs_superblock_t;
 
@@ -285,6 +304,10 @@ typedef struct lfs {
 
     lfs_free_t free;
     bool deorphaned;
+
+    lfs_size_t inline_size;
+    lfs_size_t attrs_size;
+    lfs_size_t name_size;
 } lfs_t;
 
 

--- a/lfs.h
+++ b/lfs.h
@@ -283,7 +283,7 @@ typedef struct lfs_cache {
 typedef struct lfs_file {
     struct lfs_file *next;
     lfs_block_t pair[2];
-    lfs_off_t poff;
+    lfs_off_t pairoff;
 
     lfs_block_t head;
     lfs_size_t size;
@@ -294,6 +294,9 @@ typedef struct lfs_file {
     lfs_block_t block;
     lfs_off_t off;
     lfs_cache_t cache;
+
+    const struct lfs_attr *attrs;
+    int attrcount;
 } lfs_file_t;
 
 typedef struct lfs_dir {

--- a/lfs.h
+++ b/lfs.h
@@ -52,17 +52,17 @@ typedef uint32_t lfs_block_t;
 
 // Maximum inline file size in bytes
 #ifndef LFS_INLINE_MAX
-#define LFS_INLINE_MAX 255
+#define LFS_INLINE_MAX 0x3ff
 #endif
 
 // Maximum size of all attributes per file in bytes
 #ifndef LFS_ATTRS_MAX
-#define LFS_ATTRS_MAX 255
+#define LFS_ATTRS_MAX 0x3f
 #endif
 
 // Max name size in bytes
 #ifndef LFS_NAME_MAX
-#define LFS_NAME_MAX 255
+#define LFS_NAME_MAX 0xff
 #endif
 
 // Possible error codes, these are negative to allow
@@ -248,6 +248,7 @@ typedef struct lfs_file {
     lfs_size_t size;
 
     uint32_t flags;
+    lfs_size_t inline_size;
     lfs_off_t pos;
     lfs_block_t block;
     lfs_off_t off;

--- a/lfs.h
+++ b/lfs.h
@@ -1,19 +1,8 @@
 /*
  * The little filesystem
  *
- * Copyright (c) 2017 ARM Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef LFS_H
 #define LFS_H

--- a/lfs_util.c
+++ b/lfs_util.c
@@ -1,19 +1,8 @@
 /*
  * lfs util functions
  *
- * Copyright (c) 2017 ARM Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #include "lfs_util.h"
 

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -1,19 +1,8 @@
 /*
  * lfs utility functions
  *
- * Copyright (c) 2017 ARM Limited
- *
- * Licensed under the Apache License, Version 2.0 (the "License");
- * you may not use this file except in compliance with the License.
- * You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
+ * Copyright (c) 2017, Arm Limited. All rights reserved.
+ * SPDX-License-Identifier: BSD-3-Clause
  */
 #ifndef LFS_UTIL_H
 #define LFS_UTIL_H

--- a/tests/test.py
+++ b/tests/test.py
@@ -10,7 +10,7 @@ def generate(test):
         template = file.read()
 
     lines = []
-    for line in re.split('(?<=[;{}])\n', test.read()):
+    for line in re.split('(?<=(?:.;| [{}]))\n', test.read()):
         match = re.match('(?: *\n)*( *)(.*)=>(.*);', line, re.DOTALL | re.MULTILINE)
         if match:
             tab, test, expect = match.groups()

--- a/tests/test_alloc.sh
+++ b/tests/test_alloc.sh
@@ -274,9 +274,12 @@ TEST
 tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
 
-    // create one block whole for half a directory
+    // create one block hole for half a directory
     lfs_file_open(&lfs, &file[0], "bump", LFS_O_WRONLY | LFS_O_CREAT) => 0;
-    lfs_file_write(&lfs, &file[0], (void*)"hi", 2) => 2;
+    for (lfs_size_t i = 0; i < cfg.block_size; i += 2) {
+        memcpy(&buffer[i], "hi", 2);
+    }
+    lfs_file_write(&lfs, &file[0], buffer, cfg.block_size) => cfg.block_size;
     lfs_file_close(&lfs, &file[0]) => 0;
 
     lfs_file_open(&lfs, &file[0], "exhaustion", LFS_O_WRONLY | LFS_O_CREAT);
@@ -295,7 +298,10 @@ tests/test.py << TEST
     lfs_mkdir(&lfs, "splitdir") => 0;
     lfs_file_open(&lfs, &file[0], "splitdir/bump",
             LFS_O_WRONLY | LFS_O_CREAT) => 0;
-    lfs_file_write(&lfs, &file[0], buffer, size) => LFS_ERR_NOSPC;
+    for (lfs_size_t i = 0; i < cfg.block_size; i += 2) {
+        memcpy(&buffer[i], "hi", 2);
+    }
+    lfs_file_write(&lfs, &file[0], buffer, cfg.block_size) => LFS_ERR_NOSPC;
     lfs_file_close(&lfs, &file[0]) => 0;
 
     lfs_unmount(&lfs) => 0;

--- a/tests/test_attrs.sh
+++ b/tests/test_attrs.sh
@@ -1,0 +1,292 @@
+#!/bin/bash
+set -eu
+
+echo "=== Attr tests ==="
+rm -rf blocks
+tests/test.py << TEST
+    lfs_format(&lfs, &cfg) => 0;
+
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_mkdir(&lfs, "hello") => 0;
+    lfs_file_open(&lfs, &file[0], "hello/hello",
+            LFS_O_WRONLY | LFS_O_CREAT) => 0;
+    lfs_file_write(&lfs, &file[0], "hello", strlen("hello"))
+            => strlen("hello");
+    lfs_file_close(&lfs, &file[0]);
+    lfs_unmount(&lfs) => 0;
+TEST
+
+echo "--- Set/get attribute ---"
+tests/test.py << TEST
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_setattrs(&lfs, "hello", (struct lfs_attr[]){
+            {'A', "aaaa",   4},
+            {'B', "bbbbbb", 6},
+            {'C', "ccccc",  5}}, 3) => 0;
+    lfs_getattrs(&lfs, "hello", (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",   4) => 0;
+    memcmp(buffer+4,  "bbbbbb", 6) => 0;
+    memcmp(buffer+10, "ccccc",  5) => 0;
+
+    lfs_setattrs(&lfs, "hello", (struct lfs_attr[]){
+            {'B', "", 0}}, 1) => 0;
+    lfs_getattrs(&lfs, "hello", (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",         4) => 0;
+    memcmp(buffer+4,  "\0\0\0\0\0\0", 6) => 0;
+    memcmp(buffer+10, "ccccc",        5) => 0;
+
+    lfs_setattrs(&lfs, "hello", (struct lfs_attr[]){
+            {'B', "dddddd", 6}}, 1) => 0;
+    lfs_getattrs(&lfs, "hello", (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",   4) => 0;
+    memcmp(buffer+4,  "dddddd", 6) => 0;
+    memcmp(buffer+10, "ccccc",  5) => 0;
+
+    lfs_setattrs(&lfs, "hello", (struct lfs_attr[]){
+            {'B', "eee", 3}}, 1) => 0;
+    lfs_getattrs(&lfs, "hello", (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",      4) => 0;
+    memcmp(buffer+4,  "eee\0\0\0", 6) => 0;
+    memcmp(buffer+10, "ccccc",     5) => 0;
+
+    lfs_setattrs(&lfs, "hello", (struct lfs_attr[]){
+            {'A', buffer, LFS_ATTRS_MAX+1}}, 1) => LFS_ERR_NOSPC;
+    lfs_setattrs(&lfs, "hello", (struct lfs_attr[]){
+            {'B', "fffffffff", 9}}, 1) => 0;
+    lfs_getattrs(&lfs, "hello", (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => LFS_ERR_RANGE;
+
+    lfs_unmount(&lfs) => 0;
+TEST
+tests/test.py << TEST
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_getattrs(&lfs, "hello", (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  9},
+            {'C', buffer+13, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",      4) => 0;
+    memcmp(buffer+4,  "fffffffff", 9) => 0;
+    memcmp(buffer+13, "ccccc",     5) => 0;
+
+    lfs_file_open(&lfs, &file[0], "hello/hello", LFS_O_RDONLY) => 0;
+    lfs_file_read(&lfs, &file[0], buffer, sizeof(buffer)) => strlen("hello");
+    memcmp(buffer, "hello", strlen("hello")) => 0;
+    lfs_file_close(&lfs, &file[0]);
+    lfs_unmount(&lfs) => 0;
+TEST
+
+echo "--- Set/get fs attribute ---"
+tests/test.py << TEST
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_fs_setattrs(&lfs, (struct lfs_attr[]){
+            {'A', "aaaa",   4},
+            {'B', "bbbbbb", 6},
+            {'C', "ccccc",  5}}, 3) => 0;
+    lfs_fs_getattrs(&lfs, (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",   4) => 0;
+    memcmp(buffer+4,  "bbbbbb", 6) => 0;
+    memcmp(buffer+10, "ccccc",  5) => 0;
+
+    lfs_fs_setattrs(&lfs, (struct lfs_attr[]){
+            {'B', "", 0}}, 1) => 0;
+    lfs_fs_getattrs(&lfs, (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",         4) => 0;
+    memcmp(buffer+4,  "\0\0\0\0\0\0", 6) => 0;
+    memcmp(buffer+10, "ccccc",        5) => 0;
+
+    lfs_fs_setattrs(&lfs, (struct lfs_attr[]){
+            {'B', "dddddd", 6}}, 1) => 0;
+    lfs_fs_getattrs(&lfs, (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",   4) => 0;
+    memcmp(buffer+4,  "dddddd", 6) => 0;
+    memcmp(buffer+10, "ccccc",  5) => 0;
+
+    lfs_fs_setattrs(&lfs, (struct lfs_attr[]){
+            {'B', "eee", 3}}, 1) => 0;
+    lfs_fs_getattrs(&lfs, (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",      4) => 0;
+    memcmp(buffer+4,  "eee\0\0\0", 6) => 0;
+    memcmp(buffer+10, "ccccc",     5) => 0;
+
+    lfs_fs_setattrs(&lfs, (struct lfs_attr[]){
+            {'A', buffer, LFS_ATTRS_MAX+1}}, 1) => LFS_ERR_NOSPC;
+    lfs_fs_setattrs(&lfs, (struct lfs_attr[]){
+            {'B', "fffffffff", 9}}, 1) => 0;
+    lfs_fs_getattrs(&lfs, (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => LFS_ERR_RANGE;
+    lfs_unmount(&lfs) => 0;
+TEST
+tests/test.py << TEST
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_fs_getattrs(&lfs, (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  9},
+            {'C', buffer+13, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",      4) => 0;
+    memcmp(buffer+4,  "fffffffff", 9) => 0;
+    memcmp(buffer+13, "ccccc",     5) => 0;
+
+    lfs_file_open(&lfs, &file[0], "hello/hello", LFS_O_RDONLY) => 0;
+    lfs_file_read(&lfs, &file[0], buffer, sizeof(buffer)) => strlen("hello");
+    memcmp(buffer, "hello", strlen("hello")) => 0;
+    lfs_file_close(&lfs, &file[0]);
+    lfs_unmount(&lfs) => 0;
+TEST
+
+echo "--- Set/get file attribute ---"
+tests/test.py << TEST
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_open(&lfs, &file[0], "hello/hello", LFS_O_WRONLY) => 0;
+
+    struct lfs_attr attr[3];
+    attr[0] = (struct lfs_attr){'A', "aaaa",   4};
+    attr[1] = (struct lfs_attr){'B', "bbbbbb", 6};
+    attr[2] = (struct lfs_attr){'C', "ccccc",  5};
+    lfs_file_setattrs(&lfs, &file[0], attr, 3) => 0;
+    lfs_file_getattrs(&lfs, &file[0], (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",   4) => 0;
+    memcmp(buffer+4,  "bbbbbb", 6) => 0;
+    memcmp(buffer+10, "ccccc",  5) => 0;
+    lfs_file_sync(&lfs, &file[0]) => 0;
+
+    attr[0] = (struct lfs_attr){'B', "", 0};
+    lfs_file_setattrs(&lfs, &file[0], attr, 1) => 0;
+    lfs_file_getattrs(&lfs, &file[0], (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",         4) => 0;
+    memcmp(buffer+4,  "\0\0\0\0\0\0", 6) => 0;
+    memcmp(buffer+10, "ccccc",        5) => 0;
+    lfs_file_sync(&lfs, &file[0]) => 0;
+
+    attr[0] = (struct lfs_attr){'B', "dddddd", 6};
+    lfs_file_setattrs(&lfs, &file[0], attr, 1) => 0;
+    lfs_file_getattrs(&lfs, &file[0], (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",   4) => 0;
+    memcmp(buffer+4,  "dddddd", 6) => 0;
+    memcmp(buffer+10, "ccccc",  5) => 0;
+    lfs_file_sync(&lfs, &file[0]) => 0;
+
+    attr[0] = (struct lfs_attr){'B', "eee", 3};
+    lfs_file_setattrs(&lfs, &file[0], attr, 1);
+    lfs_file_getattrs(&lfs, &file[0], (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",      4) => 0;
+    memcmp(buffer+4,  "eee\0\0\0", 6) => 0;
+    memcmp(buffer+10, "ccccc",     5) => 0;
+    lfs_file_sync(&lfs, &file[0]) => 0;
+
+    attr[0] = (struct lfs_attr){'A', buffer, LFS_ATTRS_MAX+1};
+    lfs_file_setattrs(&lfs, &file[0], attr, 1) => LFS_ERR_NOSPC;
+    attr[0] = (struct lfs_attr){'B', "fffffffff", 9};
+    lfs_file_open(&lfs, &file[1], "hello/hello", LFS_O_RDONLY) => 0;
+    lfs_file_setattrs(&lfs, &file[1], attr, 1) => LFS_ERR_BADF;
+    lfs_file_close(&lfs, &file[1]) => 0;
+    lfs_file_setattrs(&lfs, &file[0], attr, 1) => 0;
+    lfs_file_getattrs(&lfs, &file[0], (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  6},
+            {'C', buffer+10, 5}}, 3) => LFS_ERR_RANGE;
+
+    lfs_file_close(&lfs, &file[0]) => 0;
+    lfs_unmount(&lfs) => 0;
+TEST
+tests/test.py << TEST
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_open(&lfs, &file[0], "hello/hello", LFS_O_RDONLY) => 0;
+
+    lfs_file_getattrs(&lfs, &file[0], (struct lfs_attr[]){
+            {'A', buffer,    4},
+            {'B', buffer+4,  9},
+            {'C', buffer+13, 5}}, 3) => 0;
+    memcmp(buffer,    "aaaa",      4) => 0;
+    memcmp(buffer+4,  "fffffffff", 9) => 0;
+    memcmp(buffer+13, "ccccc",     5) => 0;
+
+    lfs_file_open(&lfs, &file[0], "hello/hello", LFS_O_RDONLY) => 0;
+    lfs_file_read(&lfs, &file[0], buffer, sizeof(buffer)) => strlen("hello");
+    memcmp(buffer, "hello", strlen("hello")) => 0;
+    lfs_file_close(&lfs, &file[0]);
+    lfs_unmount(&lfs) => 0;
+TEST
+
+echo "--- Deferred file attributes ---"
+tests/test.py << TEST
+    lfs_mount(&lfs, &cfg) => 0;
+    lfs_file_open(&lfs, &file[0], "hello/hello", LFS_O_RDWR) => 0;
+    
+    struct lfs_attr attr[] = {
+        {'B', "gggg", 4},
+        {'C', "",     0},
+        {'D', "hhhh", 4},
+    };
+
+    lfs_file_setattrs(&lfs, &file[0], attr, 3) => 0;
+    lfs_file_getattrs(&lfs, &file[0], (struct lfs_attr[]){
+            {'B', buffer,    9},
+            {'C', buffer+9,  9},
+            {'D', buffer+18, 9}}, 3) => 0;
+    memcmp(buffer,    "gggg\0\0\0\0\0",     9) => 0;
+    memcmp(buffer+9,  "\0\0\0\0\0\0\0\0\0", 9) => 0;
+    memcmp(buffer+18, "hhhh\0\0\0\0\0",     9) => 0;
+
+    lfs_getattrs(&lfs, "hello/hello", (struct lfs_attr[]){
+            {'B', buffer,    9},
+            {'C', buffer+9,  9},
+            {'D', buffer+18, 9}}, 3) => 0;
+    memcmp(buffer,    "fffffffff",          9) => 0;
+    memcmp(buffer+9,  "ccccc\0\0\0\0",      9) => 0;
+    memcmp(buffer+18, "\0\0\0\0\0\0\0\0\0", 9) => 0;
+
+    lfs_file_sync(&lfs, &file[0]) => 0;
+    lfs_getattrs(&lfs, "hello/hello", (struct lfs_attr[]){
+            {'B', buffer,    9},
+            {'C', buffer+9,  9},
+            {'D', buffer+18, 9}}, 3) => 0;
+    memcmp(buffer,    "gggg\0\0\0\0\0",     9) => 0;
+    memcmp(buffer+9,  "\0\0\0\0\0\0\0\0\0", 9) => 0;
+    memcmp(buffer+18, "hhhh\0\0\0\0\0",     9) => 0;
+
+    lfs_file_close(&lfs, &file[0]) => 0;
+    lfs_unmount(&lfs) => 0;
+TEST
+
+echo "--- Results ---"
+tests/stats.py

--- a/tests/test_corrupt.sh
+++ b/tests/test_corrupt.sh
@@ -88,7 +88,7 @@ do
     rm -rf blocks
     mkdir blocks
     lfs_mktree
-    chmod a-w blocks/$(printf '%x' $i)
+    chmod a-w blocks/$(printf '%x' $i) || true
     lfs_mktree
     lfs_chktree
 done

--- a/tests/test_corrupt.sh
+++ b/tests/test_corrupt.sh
@@ -73,7 +73,7 @@ lfs_mktree
 lfs_chktree
 
 echo "--- Block corruption ---"
-for i in {0..33}
+for i in {2..33}
 do 
     rm -rf blocks
     mkdir blocks
@@ -83,7 +83,7 @@ do
 done
 
 echo "--- Block persistance ---"
-for i in {0..33}
+for i in {2..33}
 do 
     rm -rf blocks
     mkdir blocks

--- a/tests/test_dirs.sh
+++ b/tests/test_dirs.sh
@@ -357,7 +357,7 @@ tests/test.py << TEST
 TEST
 
 echo "--- Multi-block directory with files ---"
-tests/test.py << TEST
+tests/test.py -s << TEST
     lfs_mount(&lfs, &cfg) => 0;
     lfs_mkdir(&lfs, "prickly-pear") => 0;
     for (int i = 0; i < $LARGESIZE; i++) {

--- a/tests/test_dirs.sh
+++ b/tests/test_dirs.sh
@@ -357,7 +357,7 @@ tests/test.py << TEST
 TEST
 
 echo "--- Multi-block directory with files ---"
-tests/test.py -s << TEST
+tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
     lfs_mkdir(&lfs, "prickly-pear") => 0;
     for (int i = 0; i < $LARGESIZE; i++) {

--- a/tests/test_entries.sh
+++ b/tests/test_entries.sh
@@ -1,0 +1,220 @@
+#!/bin/bash
+set -eu
+
+# Note: These tests are intended for 512 byte inline size at different
+# inline sizes they should still pass, but won't be testing anything
+
+echo "=== Directory tests ==="
+function read_file {
+cat << TEST
+
+    size = $2;
+    lfs_file_open(&lfs, &file[0], "$1", LFS_O_RDONLY) => 0;
+    lfs_file_read(&lfs, &file[0], rbuffer, size) => size;
+    memcmp(rbuffer, wbuffer, size) => 0;
+    lfs_file_close(&lfs, &file[0]) => 0;
+TEST
+}
+
+function write_file {
+cat << TEST
+
+    size = $2;
+    lfs_file_open(&lfs, &file[0], "$1",
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC) => 0;
+    memset(wbuffer, 'c', size);
+    lfs_file_write(&lfs, &file[0], wbuffer, size) => size;
+    lfs_file_close(&lfs, &file[0]) => 0;
+TEST
+}
+
+echo "--- Entry grow test ---"
+tests/test.py << TEST
+    lfs_format(&lfs, &cfg) => 0;
+
+    lfs_mount(&lfs, &cfg) => 0;
+    $(write_file "hi0" 20)
+    $(write_file "hi1" 20)
+    $(write_file "hi2" 20)
+    $(write_file "hi3" 20)
+
+    $(read_file "hi1" 20)
+    $(write_file "hi1" 200)
+
+    $(read_file "hi0" 20)
+    $(read_file "hi1" 200)
+    $(read_file "hi2" 20)
+    $(read_file "hi3" 20)
+    lfs_unmount(&lfs) => 0;
+TEST
+
+echo "--- Entry shrink test ---"
+tests/test.py << TEST
+    lfs_format(&lfs, &cfg) => 0;
+
+    lfs_mount(&lfs, &cfg) => 0;
+    $(write_file "hi0" 20)
+    $(write_file "hi1" 200)
+    $(write_file "hi2" 20)
+    $(write_file "hi3" 20)
+
+    $(read_file "hi1" 200)
+    $(write_file "hi1" 20)
+
+    $(read_file "hi0" 20)
+    $(read_file "hi1" 20)
+    $(read_file "hi2" 20)
+    $(read_file "hi3" 20)
+    lfs_unmount(&lfs) => 0;
+TEST
+
+echo "--- Entry spill test ---"
+tests/test.py << TEST
+    lfs_format(&lfs, &cfg) => 0;
+
+    lfs_mount(&lfs, &cfg) => 0;
+    $(write_file "hi0" 200)
+    $(write_file "hi1" 200)
+    $(write_file "hi2" 200)
+    $(write_file "hi3" 200)
+
+    $(read_file "hi0" 200)
+    $(read_file "hi1" 200)
+    $(read_file "hi2" 200)
+    $(read_file "hi3" 200)
+    lfs_unmount(&lfs) => 0;
+TEST
+
+echo "--- Entry push spill test ---"
+tests/test.py << TEST
+    lfs_format(&lfs, &cfg) => 0;
+
+    lfs_mount(&lfs, &cfg) => 0;
+    $(write_file "hi0" 200)
+    $(write_file "hi1" 20)
+    $(write_file "hi2" 200)
+    $(write_file "hi3" 200)
+
+    $(read_file "hi1" 20)
+    $(write_file "hi1" 200)
+
+    $(read_file "hi0" 200)
+    $(read_file "hi1" 200)
+    $(read_file "hi2" 200)
+    $(read_file "hi3" 200)
+    lfs_unmount(&lfs) => 0;
+TEST
+
+echo "--- Entry push spill two test ---"
+tests/test.py << TEST
+    lfs_format(&lfs, &cfg) => 0;
+
+    lfs_mount(&lfs, &cfg) => 0;
+    $(write_file "hi0" 200)
+    $(write_file "hi1" 20)
+    $(write_file "hi2" 200)
+    $(write_file "hi3" 200)
+    $(write_file "hi4" 200)
+
+    $(read_file "hi1" 20)
+    $(write_file "hi1" 200)
+
+    $(read_file "hi0" 200)
+    $(read_file "hi1" 200)
+    $(read_file "hi2" 200)
+    $(read_file "hi3" 200)
+    $(read_file "hi4" 200)
+    lfs_unmount(&lfs) => 0;
+TEST
+
+echo "--- Entry drop test ---"
+tests/test.py << TEST
+    lfs_format(&lfs, &cfg) => 0;
+
+    lfs_mount(&lfs, &cfg) => 0;
+    $(write_file "hi0" 200)
+    $(write_file "hi1" 200)
+    $(write_file "hi2" 200)
+    $(write_file "hi3" 200)
+
+    lfs_remove(&lfs, "hi1") => 0;
+    lfs_stat(&lfs, "hi1", &info) => LFS_ERR_NOENT;
+    $(read_file "hi0" 200)
+    $(read_file "hi2" 200)
+    $(read_file "hi3" 200)
+
+    lfs_remove(&lfs, "hi2") => 0;
+    lfs_stat(&lfs, "hi2", &info) => LFS_ERR_NOENT;
+    $(read_file "hi0" 200)
+    $(read_file "hi3" 200)
+
+    lfs_remove(&lfs, "hi3") => 0;
+    lfs_stat(&lfs, "hi3", &info) => LFS_ERR_NOENT;
+    $(read_file "hi0" 200)
+
+    lfs_remove(&lfs, "hi0") => 0;
+    lfs_stat(&lfs, "hi0", &info) => LFS_ERR_NOENT;
+    lfs_unmount(&lfs) => 0;
+TEST
+
+echo "--- Create too big ---"
+tests/test.py << TEST
+    lfs_format(&lfs, &cfg) => 0;
+
+    lfs_mount(&lfs, &cfg) => 0;
+    memset(buffer, 'm', 200);
+    buffer[200] = '\0';
+
+    size = 400;
+    lfs_file_open(&lfs, &file[0], (char*)buffer,
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC) => 0;
+    memset(wbuffer, 'c', size);
+    lfs_file_write(&lfs, &file[0], wbuffer, size) => size;
+    lfs_file_close(&lfs, &file[0]) => 0;
+
+    size = 400;
+    lfs_file_open(&lfs, &file[0], (char*)buffer, LFS_O_RDONLY) => 0;
+    lfs_file_read(&lfs, &file[0], rbuffer, size) => size;
+    memcmp(rbuffer, wbuffer, size) => 0;
+    lfs_file_close(&lfs, &file[0]) => 0;
+    lfs_unmount(&lfs) => 0;
+TEST
+
+echo "--- Resize too big ---"
+tests/test.py << TEST
+    lfs_format(&lfs, &cfg) => 0;
+
+    lfs_mount(&lfs, &cfg) => 0;
+    memset(buffer, 'm', 200);
+    buffer[200] = '\0';
+
+    size = 40;
+    lfs_file_open(&lfs, &file[0], (char*)buffer,
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC) => 0;
+    memset(wbuffer, 'c', size);
+    lfs_file_write(&lfs, &file[0], wbuffer, size) => size;
+    lfs_file_close(&lfs, &file[0]) => 0;
+
+    size = 40;
+    lfs_file_open(&lfs, &file[0], (char*)buffer, LFS_O_RDONLY) => 0;
+    lfs_file_read(&lfs, &file[0], rbuffer, size) => size;
+    memcmp(rbuffer, wbuffer, size) => 0;
+    lfs_file_close(&lfs, &file[0]) => 0;
+
+    size = 400;
+    lfs_file_open(&lfs, &file[0], (char*)buffer,
+            LFS_O_WRONLY | LFS_O_CREAT | LFS_O_TRUNC) => 0;
+    memset(wbuffer, 'c', size);
+    lfs_file_write(&lfs, &file[0], wbuffer, size) => size;
+    lfs_file_close(&lfs, &file[0]) => 0;
+
+    size = 400;
+    lfs_file_open(&lfs, &file[0], (char*)buffer, LFS_O_RDONLY) => 0;
+    lfs_file_read(&lfs, &file[0], rbuffer, size) => size;
+    memcmp(rbuffer, wbuffer, size) => 0;
+    lfs_file_close(&lfs, &file[0]) => 0;
+    lfs_unmount(&lfs) => 0;
+TEST
+
+echo "--- Results ---"
+tests/stats.py

--- a/tests/test_format.sh
+++ b/tests/test_format.sh
@@ -30,19 +30,9 @@ echo "--- Invalid mount ---"
 tests/test.py << TEST
     lfs_format(&lfs, &cfg) => 0;
 TEST
-rm blocks/0 blocks/1
+rm -f blocks/0 blocks/1
 tests/test.py << TEST
     lfs_mount(&lfs, &cfg) => LFS_ERR_CORRUPT;
-TEST
-
-echo "--- Valid corrupt mount ---"
-tests/test.py << TEST
-    lfs_format(&lfs, &cfg) => 0;
-TEST
-rm blocks/0
-tests/test.py << TEST
-    lfs_mount(&lfs, &cfg) => 0;
-    lfs_unmount(&lfs) => 0;
 TEST
 
 echo "--- Results ---"

--- a/tests/test_paths.sh
+++ b/tests/test_paths.sh
@@ -123,5 +123,23 @@ tests/test.py << TEST
     lfs_unmount(&lfs) => 0;
 TEST
 
+echo "--- Max path test ---"
+tests/test.py << TEST
+    lfs_mount(&lfs, &cfg) => 0;
+    memset(buffer, 'w', LFS_NAME_MAX+1);
+    buffer[LFS_NAME_MAX+2] = '\0';
+    lfs_mkdir(&lfs, (char*)buffer) => LFS_ERR_NAMETOOLONG;
+    lfs_file_open(&lfs, &file[0], (char*)buffer,
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NAMETOOLONG;
+
+    memcpy(buffer, "coffee/", strlen("coffee/"));
+    memset(buffer+strlen("coffee/"), 'w', LFS_NAME_MAX+1);
+    buffer[strlen("coffee/")+LFS_NAME_MAX+2] = '\0';
+    lfs_mkdir(&lfs, (char*)buffer) => LFS_ERR_NAMETOOLONG;
+    lfs_file_open(&lfs, &file[0], (char*)buffer,
+            LFS_O_WRONLY | LFS_O_CREAT) => LFS_ERR_NAMETOOLONG;
+    lfs_unmount(&lfs) => 0;
+TEST
+
 echo "--- Results ---"
 tests/stats.py


### PR DESCRIPTION
Minor version bump to v1.4 - API is backwards compatible
Minor disk version bump to v1.2 - Disk structures are backwards compatible (can be upgraded)

This adds internal resizable entries, which enables inline files and custom attributes. Two features that have been heavily requested.

Note: Currently this pr needs a lot of testing! ~And big-endian support needs to be fixed~.

What's new:
- Internal support for resizing entries, this is a building block for new features
- Inline files

  Now small files (<1024B) can be inlined directly in the directory block instead of getting their own block, which can waste a lot of space on devices with large block sizes.

  Note: Because inline files must be entirely stored in a files cache, a configurable _inline_size_ attribute is written to the superblock at **format** time. If the device has less RAM and a smaller _read_size_, the filesystem won't be able to mount. By default _inline_size_ = _read_size_.

- Custom attributes

  It's now possible to get and set custom attributes on files, directories, and the superblock.

  This isn't quite the same as getxattr/setxattr, instead uses a byte identifier to lookup attributes. Additionally the API is a bit different to avoid the cost of buffering file attributes and enable atomic updates to files.

  More info over here: https://github.com/geky/littlefs/issues/23

- A function to get a count of the used blocks on the filesystem: `lfs_fs_size`

  Note: this is just a wrapper over `lfs_traverse`, but should be easier to use

Related issues:
- https://github.com/geky/littlefs/issues/23 - custom attributes
- https://github.com/geky/littlefs/pull/31 - time as custom attribute (alternative solution)
- https://github.com/geky/littlefs/issues/22 - alen questions
- https://github.com/geky/littlefs/issues/29 - nand devices (inline files can help)
- https://github.com/geky/littlefs/issues/11 - internal flash devices (inline files can help)
- https://github.com/geky/littlefs/issues/45 - available space question

TODO:

- [x] Fix big-endian support
- [ ] Fix littlefs-fuse support
- [x] Prevent reading attributes with bad length
- [x] Add tests for resizable entries
- [x] Add tests for inline files
- [x] Add tests for custom attributes
- [ ] Update DESIGN.md with design changes
- [ ] Update SPEC.md with spec changes
- [ ] Update README.md?
- [ ] Clean up commit history

