### PR TITLE
Fix some compiler warnings: shadowed variable and unused parameters

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,7 @@ ifdef WORD
 override CFLAGS += -m$(WORD)
 endif
 override CFLAGS += -I.
-override CFLAGS += -std=c99 -Wall -pedantic
+override CFLAGS += -std=c99 -Wall -pedantic -Wshadow -Wunused-parameter
 
 
 all: $(TARGET)

--- a/lfs.c
+++ b/lfs.c
@@ -836,7 +836,7 @@ nextname:
 
         // find entry matching name
         while (true) {
-            int err = lfs_dir_next(lfs, dir, entry);
+            err = lfs_dir_next(lfs, dir, entry);
             if (err) {
                 return err;
             }

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -158,6 +158,7 @@ static inline void *lfs_malloc(size_t size) {
 #ifndef LFS_NO_MALLOC
     return malloc(size);
 #else
+    (void)size;
     return NULL;
 #endif
 }
@@ -166,6 +167,8 @@ static inline void *lfs_malloc(size_t size) {
 static inline void lfs_free(void *p) {
 #ifndef LFS_NO_MALLOC
     free(p);
+#else
+    (void)p;
 #endif
 }
 

--- a/tests/test_files.sh
+++ b/tests/test_files.sh
@@ -30,7 +30,7 @@ TEST
 
 w_test() {
 tests/test.py << TEST
-    lfs_size_t size = $1;
+    size = $1;
     lfs_size_t chunk = 31;
     srand(0);
     lfs_mount(&lfs, &cfg) => 0;
@@ -50,7 +50,7 @@ TEST
 
 r_test() {
 tests/test.py << TEST
-    lfs_size_t size = $1;
+    size = $1;
     lfs_size_t chunk = 29;
     srand(0);
     lfs_mount(&lfs, &cfg) => 0;

--- a/tests/test_seek.sh
+++ b/tests/test_seek.sh
@@ -153,7 +153,7 @@ tests/test.py << TEST
     lfs_file_read(&lfs, &file[0], buffer, size) => size;
     memcmp(buffer, "kittycatcat", size) => 0;
 
-    lfs_size_t size = lfs_file_size(&lfs, &file[0]);
+    size = lfs_file_size(&lfs, &file[0]);
     lfs_file_seek(&lfs, &file[0], 0, LFS_SEEK_CUR) => size;
 
     lfs_file_close(&lfs, &file[0]) => 0;
@@ -202,7 +202,7 @@ tests/test.py << TEST
     lfs_file_read(&lfs, &file[0], buffer, size) => size;
     memcmp(buffer, "kittycatcat", size) => 0;
 
-    lfs_size_t size = lfs_file_size(&lfs, &file[0]);
+    size = lfs_file_size(&lfs, &file[0]);
     lfs_file_seek(&lfs, &file[0], 0, LFS_SEEK_CUR) => size;
 
     lfs_file_close(&lfs, &file[0]) => 0;
@@ -243,7 +243,7 @@ tests/test.py << TEST
     lfs_file_read(&lfs, &file[0], buffer, size) => size;
     memcmp(buffer, "kittycatcat", size) => 0;
 
-    lfs_size_t size = lfs_file_size(&lfs, &file[0]);
+    size = lfs_file_size(&lfs, &file[0]);
     lfs_file_seek(&lfs, &file[0], 0, LFS_SEEK_CUR) => size;
 
     lfs_file_close(&lfs, &file[0]) => 0;
@@ -286,7 +286,7 @@ tests/test.py << TEST
     lfs_file_read(&lfs, &file[0], buffer, size) => size;
     memcmp(buffer, "kittycatcat", size) => 0;
 
-    lfs_size_t size = lfs_file_size(&lfs, &file[0]);
+    size = lfs_file_size(&lfs, &file[0]);
     lfs_file_seek(&lfs, &file[0], 0, LFS_SEEK_CUR) => size;
 
     lfs_file_close(&lfs, &file[0]) => 0;


### PR DESCRIPTION
First off, thanks for this project!  It's nice and clean and integrates well into other embedded systems.

In this PR I've fixed a few compiler warnings, when `-Wshadow` and `-Wunused-parameter` are enabled.  Fixing these help to integrate littlefs in bigger projects that have these warnings enabled, without applying additional workarounds.

I also added a commit to enable these warnings in the Makefile here, so the problems don't crop up again.

Any feedback is most welcome.