### PR TITLE
Add quality of life improvements for main.c/test.c issues 

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,7 @@
-TARGET = lfs
+TARGET = lfs.a
+ifneq ($(wildcard test.c main.c),)
+override TARGET = lfs
+endif
 
 CC ?= gcc
 AR ?= ar
@@ -35,7 +38,9 @@ size: $(OBJ)
 .SUFFIXES:
 test: test_format test_dirs test_files test_seek test_truncate \
 	test_interspersed test_alloc test_paths test_orphan test_move test_corrupt
+	@rm test.c
 test_%: tests/test_%.sh
+
 ifdef QUIET
 	@./$< | sed -n '/^[-=]/p'
 else
@@ -44,7 +49,7 @@ endif
 
 -include $(DEP)
 
-$(TARGET): $(OBJ)
+lfs: $(OBJ)
 	$(CC) $(CFLAGS) $^ $(LFLAGS) -o $@
 
 %.a: $(OBJ)


### PR DESCRIPTION
1. Added check for main.c and test.c to decide compilation target
2. Added step to remove test.c after successful test completion

The test.c file, which contains the expanded test main, is useful when debugging why tests are failing. However, keeping the test.c file around causes problems when a later attempt is made to compile a larger project containing the littlefs directory.

Under (hopefully) normal operation, tests always pass. So it should be ok to remove the test.c file after a successful test run. Hopefully this behaviour doesn't cause too much confusion for contributors using the
tests.

On the other side of things, compiling the library with no main ends (successfully) with the "main not found" error message. By defaulting to lfs.a if neither test.c/main.c is avoid this in the common cases


should resolve https://github.com/ARMmbed/littlefs-fuse/issues/9 and resolve https://github.com/ARMmbed/littlefs/issues/20
cc @armijnhemel, @Sim4n6 