### PR TITLE
Use PRIu32 and PRIx32 format specifiers to fix warnings

### DIFF
--- a/emubd/lfs_emubd.c
+++ b/emubd/lfs_emubd.c
@@ -16,6 +16,7 @@
 #include <unistd.h>
 #include <assert.h>
 #include <stdbool.h>
+#include <inttypes.h>
 
 
 // Block device emulated on existing filesystem
@@ -85,7 +86,7 @@ int lfs_emubd_read(const struct lfs_config *cfg, lfs_block_t block,
     memset(data, 0, size);
 
     // Read data
-    snprintf(emu->child, LFS_NAME_MAX, "%x", block);
+    snprintf(emu->child, LFS_NAME_MAX, "%" PRIx32, block);
 
     FILE *f = fopen(emu->path, "rb");
     if (!f && errno != ENOENT) {
@@ -124,7 +125,7 @@ int lfs_emubd_prog(const struct lfs_config *cfg, lfs_block_t block,
     assert(block < cfg->block_count);
 
     // Program data
-    snprintf(emu->child, LFS_NAME_MAX, "%x", block);
+    snprintf(emu->child, LFS_NAME_MAX, "%" PRIx32, block);
 
     FILE *f = fopen(emu->path, "r+b");
     if (!f) {
@@ -171,7 +172,7 @@ int lfs_emubd_erase(const struct lfs_config *cfg, lfs_block_t block) {
     assert(block < cfg->block_count);
 
     // Erase the block
-    snprintf(emu->child, LFS_NAME_MAX, "%x", block);
+    snprintf(emu->child, LFS_NAME_MAX, "%" PRIx32, block);
     struct stat st;
     int err = stat(emu->path, &st);
     if (err && errno != ENOENT) {
@@ -239,4 +240,3 @@ int lfs_emubd_sync(const struct lfs_config *cfg) {
 
     return 0;
 }
-


### PR DESCRIPTION
When using `"%d"` or `"%x"` with `uint32_t` types, arm-none-eabi-gcc reports
warnings like below:

```
In file included from lfs.c:8:
lfs_util.h:45:12: warning: format '%d' expects argument of type 'int', but argument 4 has type 'lfs_block_t' {aka 'long unsigned int'} [-Wformat=]
     printf("lfs debug:%d: " fmt "\n", __LINE__, __VA_ARGS__)
            ^~~~~~~~~~~~~~~~
lfs.c:2512:21: note: in expansion of macro 'LFS_DEBUG'
                     LFS_DEBUG("Found partial move %d %d",
                     ^~~~~~~~~
lfs.c:2512:55: note: format string is defined here
                     LFS_DEBUG("Found partial move %d %d",
                                                      ~^
                                                      %ld
```

Fix this by replacing `"%d"` and `"%x"` with `"%" PRIu32` and `"%" PRIx32`.