### PR TITLE
Add C++ guards to public headers

### DIFF
--- a/emubd/lfs_emubd.h
+++ b/emubd/lfs_emubd.h
@@ -10,6 +10,11 @@
 #include "lfs.h"
 #include "lfs_util.h"
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 
 // Config options
 #ifndef LFS_EMUBD_READ_SIZE
@@ -74,5 +79,9 @@ int lfs_emubd_erase(const struct lfs_config *cfg, lfs_block_t block);
 // Sync the block device
 int lfs_emubd_sync(const struct lfs_config *cfg);
 
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif

--- a/lfs.h
+++ b/lfs.h
@@ -10,6 +10,11 @@
 #include <stdint.h>
 #include <stdbool.h>
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 
 /// Version info ///
 
@@ -459,5 +464,9 @@ int lfs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 // Returns a negative error code on failure.
 int lfs_deorphan(lfs_t *lfs);
 
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif

--- a/lfs_util.h
+++ b/lfs_util.h
@@ -34,6 +34,11 @@
 #include <stdio.h>
 #endif
 
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
 
 // Macros, may be replaced by system specific wrappers. Arguments to these
 // macros must not have side-effects as the macros can be removed for a smaller
@@ -172,6 +177,10 @@ static inline void lfs_free(void *p) {
 #endif
 }
 
+
+#ifdef __cplusplus
+} /* extern "C" */
+#endif
 
 #endif
 #endif


### PR DESCRIPTION
Even though it is perfectly possible to surround `#include "lfs.h"` with `extern "C" { ... }` directly in the C++ files, the common practice is to have such C++ guards directly in headers, even if this is a C library. The maintenance cost is basically zero (just remember to add includes "outside" the guards and code "inside"), while the gains are important (at least in my opinion):

1. Generally all C libraries do that, so it is a common practice, expected by people developing in C++. This is also true for C system headers like `stddef.h` (see `_BEGIN_STD_C` and `_END_STD_C` macros from newlib as an example) and so on.
2. If the header does not follow this common practice and application does not surround the `#include` with `extern "C" { ... }`, the project compiles perfectly fine, with no error and no warning. You only notice the problem during linking, but only if you actually use any of the lfs functions. You will then get a sort-of a cryptic message that `xxx is undefined`, which can mean a lot of other things beside the problem with `#include`.

Fixes #53 
Fixes #32