### PR TITLE
Simplified release process based on feedback

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -134,53 +134,44 @@ jobs:
         - STAGE=deploy
         - NAME=deploy
       script:
-        # Update tag for version defined in lfs.h
+        # Find version defined in lfs.h
         - LFS_VERSION=$(grep -ox '#define LFS_VERSION .*' lfs.h | cut -d ' ' -f3)
         - LFS_VERSION_MAJOR=$((0xffff & ($LFS_VERSION >> 16)))
         - LFS_VERSION_MINOR=$((0xffff & ($LFS_VERSION >>  0)))
-        - LFS_VERSION="v$LFS_VERSION_MAJOR.$LFS_VERSION_MINOR"
-        - echo "littlefs version $LFS_VERSION"
+        # Grab latests patch from repo tags, default to 0
+        - LFS_VERSION_PATCH=$(curl -f -u "$GEKY_BOT_RELEASES"
+                https://api.github.com/repos/$TRAVIS_REPO_SLUG/git/refs
+                | jq 'map(.ref | match(
+                    "refs/tags/v'"$LFS_VERSION_MAJOR"'\\.'"$LFS_VERSION_MINOR"'\\.(.*)$")
+                    .captures[].string | tonumber + 1) | max // 0')
+        # We have our new version
+        - LFS_VERSION="v$LFS_VERSION_MAJOR.$LFS_VERSION_MINOR.$LFS_VERSION_PATCH"
+        - echo "VERSION $LFS_VERSION"
         - |
-          curl -u $GEKY_BOT_RELEASES -X POST \
-            https://api.github.com/repos/$TRAVIS_REPO_SLUG/git/refs \
-            -d "{
-              \"ref\": \"refs/tags/$LFS_VERSION\",
-              \"sha\": \"$TRAVIS_COMMIT\"
-            }"
-        - |
-          curl -f -u $GEKY_BOT_RELEASES -X PATCH \
-            https://api.github.com/repos/$TRAVIS_REPO_SLUG/git/refs/tags/$LFS_VERSION \
-            -d "{
-              \"sha\": \"$TRAVIS_COMMIT\"
-            }"
-        # Create release notes from commits
-        - LFS_PREV_VERSION="v$LFS_VERSION_MAJOR.$(($LFS_VERSION_MINOR-1))"
-        - |
-          if [ $(git tag -l "$LFS_PREV_VERSION") ]
+          # Check that we're the most recent commit
+          CURRENT_COMMIT=$(curl -f -u "$GEKY_BOT_RELEASES" \
+                https://api.github.com/repos/$TRAVIS_REPO_SLUG/commits/master \
+                | jq -re '.sha')
+          if [ "$TRAVIS_COMMIT" == "$CURRENT_COMMIT" ]
           then
-            curl -u $GEKY_BOT_RELEASES -X POST \
+            # Build release notes
+            PREV=$(git tag --sort=-v:refname -l "v*.*.*" | head -1)
+            if [ ! -z "$PREV" ]
+            then
+                echo "PREV $PREV"
+                CHANGES=$'### Changes\n\n'$( \
+                    git log --oneline $PREV.. --grep='^Merge' --invert-grep)
+                printf "CHANGES\n%s\n\n" "$CHANGES"
+            fi
+            # Create the release
+            curl -f -u "$GEKY_BOT_RELEASES" -X POST \
                 https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases \
                 -d "{
                     \"tag_name\": \"$LFS_VERSION\",
-                    \"name\": \"$LFS_VERSION\"
+                    \"target_commitish\": \"$TRAVIS_COMMIT\",
+                    \"name\": \"${LFS_VERSION%.0}\",
+                    \"body\": $(jq -sR '.' <<< "$CHANGES")
                 }"
-            RELEASE=$(
-                curl -f -u $GEKY_BOT_RELEASES \
-                    https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases/tags/$LFS_VERSION
-            )
-            CHANGES=$(
-                git log --oneline $LFS_PREV_VERSION.. --grep='^Merge' --invert-grep
-            )
-            curl -f -u $GEKY_BOT_RELEASES -X PATCH \
-                https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases/$(
-                    jq -r '.id' <<< "$RELEASE"
-                ) \
-                -d "$(
-                    jq -s '{
-                        "body": ((.[0] // "" | sub("(?<=\n)#+ Changes.*"; ""; "mi"))
-                            + "### Changes\n\n" + .[1])
-                    }' <(jq '.body' <<< "$RELEASE") <(jq -sR '.' <<< "$CHANGES")
-                )"
           fi
 
 # Manage statuses


### PR DESCRIPTION
Previously, littlefs had mutable versions. That is, anytime a new commit landed on master, the bot would update the most recent version to contain the patch. The idea was that this would make sure users always had the most recent bug fixes. Immutable snapshots could be accessed through the git hashes.

However, at this point multiple developers have pointed out that this is confusing, with mutable versions being non-standard and surprising.

This new release process adopts SemVer in its entirety, with incrementing patch numbers and immutable versions.

When a new commit lands on master:
1. The major/minor version is taken from lfs.h
2. The most recent patch version is looked up on GitHub and incremented
3. A changelog is built out of the commits to the previous version
4. A new release and tag is created on GitHub

Additionally, any commits that land while CI is still running are coalesced together. Which means multiple PRs can land in a single release.

I've been testing the new script out over on this repo, if anyone wants to mess around with it:
https://github.com/geky/littlefs-test-repo/releases

Let me know your thoughts.

cc @FreddieChopin, @dpgeorge, @davidefer, @bridadan, @theotherjimmy, @kegilbert, @deepikabhavnani
should resolve https://github.com/ARMmbed/littlefs/issues/79, https://github.com/ARMmbed/littlefs/issues/50