### PR TITLE
Moved SPDX and license info into README

### DIFF
--- a/LICENSE.md
+++ b/LICENSE.md
@@ -22,15 +22,3 @@ LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON
 ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS
 SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-
----
-
-*Note*:
-Individual files contain the following tag instead of the full license text.
-
-
-
-    SPDX-License-Identifier:    BSD-3-Clause
-
-This enables machine processing of license information based on the SPDX
-License Identifiers that are here available: http://spdx.org/licenses/

--- a/README.md
+++ b/README.md
@@ -146,6 +146,19 @@ The tests assume a Linux environment and can be started with make:
 make test
 ```
 
+## License
+
+The littlefs is provided under the [BSD-3-Clause](https://spdx.org/licenses/BSD-3-Clause.html)
+license. See [LICENSE.md](LICENSE.md) for more information. Contributions to
+this project are accepted under the same license.
+
+Individual files contain the following tag instead of the full license text.
+
+    SPDX-License-Identifier:    BSD-3-Clause
+
+This enables machine processing of license information based on the SPDX
+License Identifiers that are here available: http://spdx.org/licenses/
+
 ## Related projects
 
 [Mbed OS](https://github.com/ARMmbed/mbed-os/tree/master/features/filesystem/littlefs) -


### PR DESCRIPTION
This makes is a bit easier to find the description about the SPDX tags, and fixes the issue where GitHub doesn't detect the license text.

cc @jlovejoy