### PR TITLE
Make _tell and _size use const params

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1083,7 +1083,7 @@ int lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
     return 0;
 }
 
-lfs_soff_t lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir) {
+lfs_soff_t lfs_dir_tell(const lfs_t *lfs, const lfs_dir_t *dir) {
     (void)lfs;
     return dir->pos;
 }
@@ -1807,7 +1807,7 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
     return 0;
 }
 
-lfs_soff_t lfs_file_tell(lfs_t *lfs, lfs_file_t *file) {
+lfs_soff_t lfs_file_tell(const lfs_t *lfs, const lfs_file_t *file) {
     (void)lfs;
     return file->pos;
 }
@@ -1821,7 +1821,7 @@ int lfs_file_rewind(lfs_t *lfs, lfs_file_t *file) {
     return 0;
 }
 
-lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
+lfs_soff_t lfs_file_size(const lfs_t *lfs, const lfs_file_t *file) {
     (void)lfs;
     if (file->flags & LFS_F_WRITING) {
         return lfs_max(file->pos, file->size);

--- a/lfs.h
+++ b/lfs.h
@@ -411,7 +411,7 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
 //
 // Equivalent to lfs_file_seek(lfs, file, 0, LFS_SEEK_CUR)
 // Returns the position of the file, or a negative error code on failure.
-lfs_soff_t lfs_file_tell(lfs_t *lfs, lfs_file_t *file);
+lfs_soff_t lfs_file_tell(const lfs_t *lfs, const lfs_file_t *file);
 
 // Change the position of the file to the beginning of the file
 //
@@ -423,7 +423,7 @@ int lfs_file_rewind(lfs_t *lfs, lfs_file_t *file);
 //
 // Similar to lfs_file_seek(lfs, file, 0, LFS_SEEK_END)
 // Returns the size of the file, or a negative error code on failure.
-lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file);
+lfs_soff_t lfs_file_size(const lfs_t *lfs, const lfs_file_t *file);
 
 
 /// Directory operations ///
@@ -465,7 +465,7 @@ int lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
 // sense, but does indicate the current position in the directory iteration.
 //
 // Returns the position of the directory, or a negative error code on failure.
-lfs_soff_t lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir);
+lfs_soff_t lfs_dir_tell(const lfs_t *lfs, const lfs_dir_t *dir);
 
 // Change the position of the directory to the beginning of the directory
 //


### PR DESCRIPTION
Since tell and size operations do not modify the underlying file,
these can be made const to avoid trouble interfacing with filesystems
where the file.tell() and file.size() operations are const.

This was hit while I was porting littlefs to the ESP8266 where the
File base class expects these operations to be const methods.