### PR TITLE
Prevent infinite loop in lfs_traverse

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -2259,6 +2259,7 @@ int lfs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data) {
     lfs_entry_t entry;
     lfs_block_t cwd[2] = {0, 1};
 
+    lfs_block_t dirs = 0;
     while (true) {
         for (int i = 0; i < 2; i++) {
             int err = cb(data, cwd[i]);
@@ -2296,6 +2297,11 @@ int lfs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data) {
 
         if (lfs_pairisnull(cwd)) {
             break;
+        }
+        if (dirs++ >= lfs->cfg->block_count) {
+            // If we reached here, we have more directory pairs than blocks in the
+            // filesystem... So something must be horribly wrong
+            return LFS_ERR_CORRUPT;
         }
     }
 


### PR DESCRIPTION
lfs_traverse has no protection against infinite loops. Consider what happens if a directory entry has dir.d.tail == cwd... you end up hanging forever. [Relevant section of code:](https://github.com/ARMmbed/littlefs/blob/195075819e05a9ce8568d3d98363f2a6f19ed436/lfs.c#L2294)

```
int lfs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data) {
    ...
    lfs_dir_t dir;
    lfs_block_t cwd[2]
    ...
    while (true) {
        ...
        lfs_dir_fetch(lfs, &dir, cwd);
        ...
        cwd[0] = dir.d.tail[0];
        cwd[1] = dir.d.tail[1];
        ...
    }
}
```

This is mostly a theoretical issue - this can only really happen if the on-flash data is already in an invalid state. However, as littlefs is supposed to be failsafe...

Two fixes come to mind:

1. Keep a counter. If you ever traverse >= the total number of blocks, you know that you've hit a loop. (This may take a while... but this isn't supposed to happen unless something has gone wrong _anyway_, and it's still better than just hanging forever.)
2. Use something like the tortose-and-hare algorithm. (Advance the hare, do the callback, exit if done, panic if hare == tortose, advance the hare, do the callback, exit if done, panic if hare == tortose, advance the tortose, panic if hare == tortose. Repeat.) Probably overkill.

This change implements #1.