### PR TITLE
Fix: Negative length should return error

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1755,9 +1755,13 @@ lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
     return npos;
 }
 
-int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
+int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_soff_t size) {
     if ((file->flags & 3) == LFS_O_RDONLY) {
         return LFS_ERR_BADF;
+    }
+
+    if ((size < 0) || (size > LFS_FILE_MAX)) {
+        return LFS_ERR_INVAL;
     }
 
     lfs_off_t oldsize = lfs_file_size(lfs, file);

--- a/lfs.h
+++ b/lfs.h
@@ -405,7 +405,7 @@ lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
 // Truncates the size of the file to the specified size
 //
 // Returns a negative error code on failure.
-int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
+int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_soff_t size);
 
 // Return the position of the file
 //


### PR DESCRIPTION
To make lfs_file_truncate inline with ftruncate function, when -ve
or size more than maximum file size is passed to function it should
return invalid parameter error. In LFS case LFS_ERR_INVAL.

Signed-off-by: Ajay Bhargav <contact@rickeyworld.info>