### PR TITLE
Fix: length more than LFS_FILE_MAX should return error

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -2864,6 +2864,10 @@ int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size) {
         return LFS_ERR_BADF;
     }
 
+    if (size > LFS_FILE_MAX) {
+        return LFS_ERR_INVAL;
+    }
+
     lfs_off_t oldsize = lfs_file_size(lfs, file);
     if (size < oldsize) {
         // need to flush since directly changing metadata


### PR DESCRIPTION
To make lfs_file_truncate inline with ftruncate function, when -ve
or size more than maximum file size is passed to function it should
return invalid parameter error. In LFS case LFS_ERR_INVAL.

Signed-off-by: Ajay Bhargav <contact@rickeyworld.info>