### PR TITLE
Fixed documentation for return lfs_dir_read return value.

### DIFF
--- a/lfs.h
+++ b/lfs.h
@@ -448,7 +448,8 @@ int lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir);
 // Read an entry in the directory
 //
 // Fills out the info structure, based on the specified file or directory.
-// Returns a negative error code on failure.
+// Returns a positive value on success, 0 at the end of directory,
+// or a negative error code on failure.
 int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
 
 // Change the position of the directory


### PR DESCRIPTION
lfs_dir_read breaks the convention of returning non-zero on success,
this feature should be at least documented.

This already caused some confusion in issue https://github.com/ARMmbed/littlefs/issues/114 . The documentation was not clear about return values. This PR clarifies the return values, including those that are not covered by standard error codes.