### PR TITLE
Fix missing cache flush in lfs_migrate, force lfs_migrate to erase v1

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -4399,6 +4399,11 @@ int lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg) {
                     goto cleanup;
                 }
             }
+
+            err = lfs_bd_flush(lfs, &lfs->pcache, &lfs->rcache, true);
+            if (err) {
+                goto cleanup;
+            }
         }
 
         // Create new superblock. This marks a successful migration!

--- a/lfs.c
+++ b/lfs.c
@@ -3338,6 +3338,14 @@ int lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
         if (err) {
             goto cleanup;
         }
+
+        // force compaction to prevent accidentally mounting any
+        // older version of littlefs that may live on disk
+        root.erased = false;
+        err = lfs_dir_commit(lfs, &root, NULL, 0);
+        if (err) {
+            goto cleanup;
+        }
     }
 
 cleanup:
@@ -4444,6 +4452,13 @@ int lfs_migrate(lfs_t *lfs, const struct lfs_config *cfg) {
 
         // sanity check that fetch works
         err = lfs_dir_fetch(lfs, &dir2, (const lfs_block_t[2]){0, 1});
+        if (err) {
+            goto cleanup;
+        }
+
+        // force compaction to prevent accidentally mounting v1
+        dir2.erased = false;
+        err = lfs_dir_commit(lfs, &dir2, NULL, 0);
         if (err) {
             goto cleanup;
         }


### PR DESCRIPTION
The data written to the prog cache would make littlefs internally
consistent, but because this was never written to disk, the filesystem
would become unmountable.

Unfortunately, this wasn't found during testing because caches automatically
flush if data is written up to a program boundary (maybe this was a mistake?).

Also changed lfs_migrate and lfs_format to erase the backup superblock per suggestion from @rojer. This will help prevent accidentally picking up outdated filesystem versions that may have been corrupted (discussion in #182).

Should fix https://github.com/ARMmbed/littlefs/issues/182