### PR TITLE
Mark all Python 2 scripts as Python 2

### DIFF
--- a/scripts/prefix.py
+++ b/scripts/prefix.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 # This script replaces prefixes of files, and symbols in that file.
 # Useful for creating different versions of the codebase that don't

--- a/tests/corrupt.py
+++ b/tests/corrupt.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import struct
 import sys

--- a/tests/stats.py
+++ b/tests/stats.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import struct
 import sys

--- a/tests/test.py
+++ b/tests/test.py
@@ -1,4 +1,4 @@
-#!/usr/bin/env python
+#!/usr/bin/env python2
 
 import re
 import sys


### PR DESCRIPTION
On some systems, `python` links to `python3`, so the tests fail to run.

Would there be interest in converting all these to Python 3? Since Python 2 is due for deprecation this year... I could send a PR for this. If so, is Python >=3.6 acceptable? Asking because of f-strings.