### PR TITLE
Protect file operations against reusing lfs_file_t belonging to closed files.

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -2414,6 +2414,7 @@ int lfs_file_close(lfs_t *lfs, lfs_file_t *file) {
     // clean up memory
     if (!file->cfg->buffer) {
         lfs_free(file->cache.buffer);
+        file->cache.buffer = NULL;
     }
 
     file->flags = LFS_F_CLOSED;
@@ -3326,6 +3327,8 @@ static int lfs_deinit(lfs_t *lfs) {
     if (!lfs->cfg->lookahead_buffer) {
         lfs_free(lfs->free.buffer);
     }
+
+    memset(lfs, 0, sizeof(*lfs));
 
     return 0;
 }

--- a/lfs.h
+++ b/lfs.h
@@ -136,6 +136,7 @@ enum lfs_open_flags {
     LFS_F_READING = 0x040000, // File has been read since last flush
     LFS_F_ERRED   = 0x080000, // An error occured during write
     LFS_F_INLINE  = 0x100000, // Currently inlined in directory entry
+    LFS_F_CLOSED  = 0x200000, // File has been closed
 };
 
 // File seek flags


### PR DESCRIPTION
Do not allow file operations (except lfs_file_open) on closed files by erroneous reuse lfs_file_t stucture.
It is achived by adding new internal file flag. This flag is set in lfs_file_close and it is tested in each (file related) API call as a precondition.

I also added patch to not allow using of pointers to deallocated memory (some kind of defensive programming).