### PR TITLE
removed <dirent.h> preventing compile on some archs

### DIFF
--- a/emubd/lfs_emubd.c
+++ b/emubd/lfs_emubd.c
@@ -11,7 +11,7 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <limits.h>
-#include <dirent.h>
+//#include <dirent.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <assert.h>

--- a/emubd/lfs_emubd.c
+++ b/emubd/lfs_emubd.c
@@ -11,7 +11,6 @@
 #include <stdlib.h>
 #include <stdio.h>
 #include <limits.h>
-//#include <dirent.h>
 #include <sys/stat.h>
 #include <unistd.h>
 #include <assert.h>


### PR DESCRIPTION
On some architectures `<dirent.h>` is not available (preventing the code from compiling); meanwhile, the code does not appear to use any of [the documented functionality of the same](https://pubs.opengroup.org/onlinepubs/7908799/xsh/dirent.h.html):

> ##### [ ]()DESCRIPTION
> 
> The internal format of directories is unspecified.
> 
> > The _&lt;dirent.h&gt;_ header defines the following data type through **typedef**:
> 
> DIR
> 
> A type representing a directory stream.
> 
> > It also defines the structure **dirent** which includes the following members:
> 
> ino_t  d_ino       file serial number
> char   d_name[]    name of entry
> 
> > The type **ino_t** is defined as described in _[&lt;sys/types.h&gt;](https://pubs.opengroup.org/onlinepubs/7908799/xsh/systypes.h.html)_.
> 
> > The character array **d_name** is of unspecified size, but the number of bytes preceding the terminating null byte will not exceed {NAME_MAX}.
> 
> > The following are declared as functions and may also be defined as macros. Function prototypes must be provided for use with an ISO C compiler.
> 
> int            [closedir](https://pubs.opengroup.org/onlinepubs/7908799/xsh/closedir.html)(DIR *);
> DIR           *[opendir](https://pubs.opengroup.org/onlinepubs/7908799/xsh/opendir.html)(const char *);
> struct dirent *[readdir](https://pubs.opengroup.org/onlinepubs/7908799/xsh/readdir.html)(DIR *);
> int            [readdir_r](https://pubs.opengroup.org/onlinepubs/7908799/xsh/readdir_r.html)(DIR *, struct dirent *, struct dirent **);
> void           [rewinddir](https://pubs.opengroup.org/onlinepubs/7908799/xsh/rewinddir.html)(DIR *);
> void           [seekdir](https://pubs.opengroup.org/onlinepubs/7908799/xsh/seekdir.html)(DIR *, long int);
> long int       [telldir](https://pubs.opengroup.org/onlinepubs/7908799/xsh/telldir.html)(DIR *);

The code appears to build fine without it, at least on `x86_64-apple-darwin18.6.0` and on `riscv32-unknown-elf`. It would be rather odd (and possibly depending on undocumented functionality?) if this removal thus prevented the code from compiling on any other architectures / in any other environments.