### PR TITLE
Change block_cycles disable from 0 to -1

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -111,7 +111,7 @@ jobs:
       if: branch !~ -prefix$
       install:
         - sudo apt-get install libfuse-dev
-        - git clone --depth 1 https://github.com/geky/littlefs-fuse -b v2-alpha
+        - git clone --depth 1 https://github.com/geky/littlefs-fuse -b v2
         - fusermount -V
         - gcc --version
       before_script:
@@ -146,7 +146,7 @@ jobs:
       if: branch !~ -prefix$
       install:
         - sudo apt-get install libfuse-dev
-        - git clone --depth 1 https://github.com/geky/littlefs-fuse -b v2-alpha v2
+        - git clone --depth 1 https://github.com/geky/littlefs-fuse -b v2 v2
         - git clone --depth 1 https://github.com/geky/littlefs-fuse -b v1 v1
         - fusermount -V
         - gcc --version

--- a/lfs.c
+++ b/lfs.c
@@ -1453,7 +1453,7 @@ static int lfs_dir_compact(lfs_t *lfs,
 
     // increment revision count
     dir->rev += 1;
-    if (lfs->cfg->block_cycles &&
+    if (lfs->cfg->block_cycles > 0 &&
             (dir->rev % (lfs->cfg->block_cycles+1) == 0)) {
         if (lfs_pair_cmp(dir->pair, (const lfs_block_t[2]){0, 1}) == 0) {
             // oh no! we're writing too much to the superblock,
@@ -3192,8 +3192,10 @@ static int lfs_init(lfs_t *lfs, const struct lfs_config *cfg) {
     LFS_ASSERT(4*lfs_npw2(0xffffffff / (lfs->cfg->block_size-2*4))
             <= lfs->cfg->block_size);
 
-    // we don't support some corner cases
-    LFS_ASSERT(lfs->cfg->block_cycles < 0xffffffff);
+    // block_cycles = 0 is no longer supported, must either set a number
+    // of erase cycles before moving logs to another block (~500 suggested),
+    // or explicitly disable wear-leveling with -1.
+    LFS_ASSERT(lfs->cfg->block_cycles != 0);
 
     // setup read cache
     if (lfs->cfg->read_buffer) {

--- a/lfs.c
+++ b/lfs.c
@@ -3192,10 +3192,14 @@ static int lfs_init(lfs_t *lfs, const struct lfs_config *cfg) {
     LFS_ASSERT(4*lfs_npw2(0xffffffff / (lfs->cfg->block_size-2*4))
             <= lfs->cfg->block_size);
 
-    // block_cycles = 0 is no longer supported, must either set a number
-    // of erase cycles before moving logs to another block (~500 suggested),
-    // or explicitly disable wear-leveling with -1.
+    // block_cycles = 0 is no longer supported.
+    //
+    // block_cycles is the number of erase cycles before littlefs evicts
+    // metadata logs as a part of wear leveling. Suggested values are in the
+    // range of 100-1000, or set block_cycles to -1 to disable block-level
+    // wear-leveling.
     LFS_ASSERT(lfs->cfg->block_cycles != 0);
+
 
     // setup read cache
     if (lfs->cfg->read_buffer) {

--- a/lfs.h
+++ b/lfs.h
@@ -190,9 +190,10 @@ struct lfs_config {
     // Number of erasable blocks on the device.
     lfs_size_t block_count;
 
-    // Number of erase cycles before we should move logs to another block.
-    // Suggested values are in the range 100-1000, with large values having
-    // better performance at the cost of less consistent wear distribution.
+    // Number of erase cycles before littlefs evicts metadata logs and moves 
+    // the metadata to another block. Suggested values are in the
+    // range 100-1000, with large values having better performance at the cost
+    // of less consistent wear distribution.
     //
     // Set to -1 to disable block-level wear-leveling.
     int32_t block_cycles;

--- a/lfs.h
+++ b/lfs.h
@@ -190,9 +190,12 @@ struct lfs_config {
     // Number of erasable blocks on the device.
     lfs_size_t block_count;
 
-    // Number of erase cycles before we should move data to another block.
-    // May be zero, in which case no block-level wear-leveling is performed.
-    uint32_t block_cycles;
+    // Number of erase cycles before we should move logs to another block.
+    // Suggested values are in the range 100-1000, with large values having
+    // better performance at the cost of less consistent wear distribution.
+    //
+    // Set to -1 to disable block-level wear-leveling.
+    int32_t block_cycles;
 
     // Size of block caches. Each cache buffers a portion of a block in RAM.
     // The littlefs needs a read cache, a program cache, and one additional


### PR DESCRIPTION
As it is now, block_cycles = 0 disables wear leveling. This was a mistake. 0 is the "default" value for several other config options and makes it easy to accidentally disable wear-leveling. It's even worse when migrating from v1 as it's easy to miss the addition of block_cycles and end up with a filesystem that is not actually wear-leveling.

Clearly, block_cycles = 0 should do anything but disable wear-leveling.

Here, I've changed block_cycles = 0 to assert. Forcing users to set a value for block_cycles (500 is suggested). block_cycles can be set to -1 to explicitly disable wear leveling if desired.

Related: https://github.com/ARMmbed/littlefs/issues/189