### PR TITLE
Protect (LFS_ASSERT) file operations against using not opened or closed files.

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -2262,7 +2262,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
     // setup simple file details
     int err;
     file->cfg = cfg;
-    file->flags = flags;
+    file->flags = flags | LFS_F_OPENED;
     file->pos = 0;
     file->cache.buffer = NULL;
 
@@ -2383,8 +2383,6 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
             }
         }
     }
-
-    file->flags |= LFS_F_OPENED;
 
     return 0;
 
@@ -2514,7 +2512,7 @@ static int lfs_file_flush(lfs_t *lfs, lfs_file_t *file) {
             lfs_file_t orig = {
                 .ctz.head = file->ctz.head,
                 .ctz.size = file->ctz.size,
-                .flags = LFS_O_RDONLY,
+                .flags = LFS_O_RDONLY | LFS_F_OPENED,
                 .pos = file->pos,
                 .cache = lfs->rcache,
             };

--- a/lfs.h
+++ b/lfs.h
@@ -136,6 +136,7 @@ enum lfs_open_flags {
     LFS_F_READING = 0x040000, // File has been read since last flush
     LFS_F_ERRED   = 0x080000, // An error occured during write
     LFS_F_INLINE  = 0x100000, // Currently inlined in directory entry
+    LFS_F_OPENED  = 0x200000, // File has been opened
 };
 
 // File seek flags


### PR DESCRIPTION
Do not allow some file operations to (re)use lfs_file_t stucture when file is already opened (prohibit open) or not opened/closed (prohibit all operations but open).
It is achieved by adding new internal file flag. This flag is set in lfs_file_open and it is reset in lfs_file_close. It is also tested in each (file related) API call as an ASSERTprecondition.
This is second attempt to add this functionality after discussion in pull request [#213](https://github.com/ARMmbed/littlefs/pull/213).