### PR TITLE
lfs: correct alignment restriction on lookahead buffer

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -3412,10 +3412,10 @@ static int lfs_init(lfs_t *lfs, const struct lfs_config *cfg) {
     lfs_cache_zero(lfs, &lfs->rcache);
     lfs_cache_zero(lfs, &lfs->pcache);
 
-    // setup lookahead, must be multiple of 64-bits
+    // setup lookahead, must be multiple of 64-bits, 32-bit aligned
     LFS_ASSERT(lfs->cfg->lookahead_size > 0);
     LFS_ASSERT(lfs->cfg->lookahead_size % 8 == 0 &&
-            (uintptr_t)lfs->cfg->lookahead_buffer % 8 == 0);
+            (uintptr_t)lfs->cfg->lookahead_buffer % 4 == 0);
     if (lfs->cfg->lookahead_buffer) {
         lfs->free.buffer = lfs->cfg->lookahead_buffer;
     } else {


### PR DESCRIPTION
The buffer need only be 32-bit aligned.

Signed-off-by: Peter A. Bigot <pab@pabigot.com>