### PR TITLE
Fix if vs ifdef condition on LFS_MIGRATE

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1500,7 +1500,7 @@ static int lfs_dir_compact(lfs_t *lfs,
                     end = begin;
                 }
             }
-#if LFS_MIGRATE
+#ifdef LFS_MIGRATE
         } else if (lfs_pair_cmp(dir->pair, lfs->root) == 0 && lfs->lfs1) {
             // we can't relocate our root during migrations, as this would
             // cause the superblock to get updated, which would clobber v1


### PR DESCRIPTION
Found by @e107steved: https://github.com/ARMmbed/littlefs/issues/247
> Version 2.1.0 release, line 1503 of lfs.c has "#if LFS_MIGRATE". All other instances are "#ifdef LFS_MIGRATE"