### PR TITLE
Changed CI to create release note for patches

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -248,34 +248,30 @@ jobs:
                   -m "Generated v$LFS_VERSION_MAJOR prefixes")
           git reset --hard
           # Update major version branches (vN and vN-prefix)
-          git push https://$GEKY_BOT_RELEASES@github.com/$TRAVIS_REPO_SLUG.git \
+          git push --atomic https://$GEKY_BOT_RELEASES@github.com/$TRAVIS_REPO_SLUG.git \
               v$LFS_VERSION_MAJOR \
               v$LFS_VERSION_MAJOR-prefix
-          # Create patch version tag (vN.N.N)
-          curl -f -u "$GEKY_BOT_RELEASES" -X POST \
-              https://api.github.com/repos/$TRAVIS_REPO_SLUG/git/refs \
-              -d "{
-                  \"ref\": \"refs/tags/$LFS_VERSION\",
-                  \"sha\": \"$TRAVIS_COMMIT\"
-              }"
-          # Create minor release?
-          [[ "$LFS_VERSION" == *.0 ]] || exit 0
           # Build release notes
-          PREV=$(git tag --sort=-v:refname -l "v*.0" | head -1)
+          PREV=$(git tag --sort=-v:refname -l "v*" | head -1)
           if [ ! -z "$PREV" ]
           then
               echo "PREV $PREV"
-              CHANGES=$'### Changes\n\n'$( \
-                  git log --oneline $PREV.. --grep='^Merge' --invert-grep)
+              CHANGES=$(git log --oneline $PREV.. --grep='^Merge' --invert-grep)
               printf "CHANGES\n%s\n\n" "$CHANGES"
           fi
-          # Create the release
+          case ${GEKY_BOT_DRAFT:-minor} in
+              true)  DRAFT=true ;;
+              minor) DRAFT=$(jq -R 'endswith(".0")' <<< "$LFS_VERSION") ;;
+              false) DRAFT=false ;;
+          esac
+          # Create the release and patch version tag (vN.N.N)
           curl -f -u "$GEKY_BOT_RELEASES" -X POST \
               https://api.github.com/repos/$TRAVIS_REPO_SLUG/releases \
               -d "{
                   \"tag_name\": \"$LFS_VERSION\",
                   \"name\": \"${LFS_VERSION%.0}\",
-                  \"draft\": true,
+                  \"target_commitish\": \"$TRAVIS_COMMIT\",
+                  \"draft\": $DRAFT,
                   \"body\": $(jq -sR '.' <<< "$CHANGES")
               }" #"
           SCRIPT


### PR DESCRIPTION
This is a result of feedback that the current release notes made it too difficult to see what changes happened on patch releases. From my experience as well it became difficult to chase down which release a commit landed on.

The risk is that this creates additional noise, both for the release page and for user notifications. I am open to feedback if this causes a problem.

Other tweaks on the CI side, these came from iteration with the same scheme for coru and equeue:

- Changed version branch updates to be atomic (vN and vN-prefix). This makes it a bit easier to fix if one of the pushes fails due to a rogue branch with the same name.

- Added GEKY_BOT_DRAFT as a CI macro that can optionally switch between only creating drafts or immediately posting a release. The default is what I will be trying with littlefs which is to draft minor/major releases, but automatically create patch release.

  The real benefit of automatic releases is to use on tiny repos that don't really have an active maintainer. Though this is definitely no longer the case with littlefs, and I'm happy it has gained this much attention.

cc @FreddieChopin 