### PR TITLE
lfs: Validate lfs-cfg sizes before performing any arithmetic logics with them

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -3369,6 +3369,12 @@ static int lfs_init(lfs_t *lfs, const struct lfs_config *cfg) {
     lfs->cfg = cfg;
     int err = 0;
 
+    // validate that the lfs-cfg sizes were initiated properly before
+    // performing any arithmetic logics with them
+    LFS_ASSERT(lfs->cfg->read_size != 0);
+    LFS_ASSERT(lfs->cfg->prog_size != 0);
+    LFS_ASSERT(lfs->cfg->cache_size != 0);
+
     // check that block size is a multiple of cache size is a multiple
     // of prog and read sizes
     LFS_ASSERT(lfs->cfg->cache_size % lfs->cfg->read_size == 0);


### PR DESCRIPTION
Since `lfs_init` validates lfs config attributes, it should also check that the attributes are initiated properly, in order to not crash, for example, if `read_size` or `prog_size` or `cache_size` are not set (floating point excpetion).

Also, those attributes are really critical for lfs, and if the user didn't set those values, he must be aware of that (assertion error is pretty indicative, unlike a weird floating point exception..).