### PR TITLE
build: Fix warnings about shift count width difference for 16 bit com…

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -352,7 +352,7 @@ static inline bool lfs_gstate_hasmovehere(const struct lfs_gstate *a,
 
 static inline void lfs_gstate_xororphans(struct lfs_gstate *a,
         const struct lfs_gstate *b, bool orphans) {
-    a->tag ^= LFS_MKTAG(0x800, 0, 0) & (b->tag ^ (orphans << 31));
+    a->tag ^= LFS_MKTAG(0x800, 0, 0) & (b->tag ^ ((uint32_t)orphans << 31));
 }
 
 static inline void lfs_gstate_xormove(struct lfs_gstate *a,
@@ -846,7 +846,7 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
                 }
 
                 // reset the next bit if we need to
-                ptag ^= (lfs_tag_chunk(tag) & 1U) << 31;
+                ptag ^= (lfs_tag_t)(lfs_tag_chunk(tag) & 1U) << 31;
 
                 // toss our crc into the filesystem seed for
                 // pseudorandom numbers
@@ -1275,7 +1275,7 @@ static int lfs_dir_commitcrc(lfs_t *lfs, struct lfs_commit *commit) {
         }
 
         commit->off += sizeof(tag)+lfs_tag_size(tag);
-        commit->ptag = tag ^ (reset << 31);
+        commit->ptag = tag ^ ((lfs_tag_t)reset << 31);
         commit->crc = LFS_BLOCK_NULL; // reset crc for next "commit"
     }
 


### PR DESCRIPTION
Build warnings exist on a gcc based 16 bit compiler. Cast relevant types
to fix.

littlefs/lfs.c: In function 'lfs_gstate_xororphans':
littlefs/lfs.c:355:5: warning: left shift count >= width of type
littlefs/lfs.c: In function 'lfs_dir_fetchmatch':
littlefs/lfs.c:849:17: warning: left shift count >= width of type
littlefs/lfs.c: In function 'lfs_dir_commitcrc':
littlefs/lfs.c:1278:9: warning: left shift count >= width of type