### PR TITLE
fix types for 16bit machines

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -2941,7 +2941,7 @@ lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
     LFS_ASSERT(file->flags & LFS_F_OPENED);
 
     // write out everything beforehand, may be noop if rdonly
-    int err = lfs_file_flush(lfs, file);
+    lfs_soff_t err = (lfs_soff_t)lfs_file_flush(lfs, file);
     if (err) {
         LFS_TRACE("lfs_file_seek -> %"PRId32, err);
         return err;
@@ -2960,7 +2960,7 @@ lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
     if (npos > lfs->file_max) {
         // file position out of range
         LFS_TRACE("lfs_file_seek -> %"PRId32, LFS_ERR_INVAL);
-        return LFS_ERR_INVAL;
+        return (lfs_soff_t)LFS_ERR_INVAL;
     }
 
     // update pos

--- a/lfs.c
+++ b/lfs.c
@@ -3569,7 +3569,7 @@ cleanup:
     return err;
 }
 
-int lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
+lfs_stag_t lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
     LFS_TRACE("lfs_mount(%p, %p {.context=%p, "
                 ".read=%p, .prog=%p, .erase=%p, .sync=%p, "
                 ".read_size=%"PRIu32", .prog_size=%"PRIu32", "
@@ -3586,7 +3586,7 @@ int lfs_mount(lfs_t *lfs, const struct lfs_config *cfg) {
             cfg->block_cycles, cfg->cache_size, cfg->lookahead_size,
             cfg->read_buffer, cfg->prog_buffer, cfg->lookahead_buffer,
             cfg->name_max, cfg->file_max, cfg->attr_max);
-    int err = lfs_init(lfs, cfg);
+    lfs_stag_t err = (lfs_stag_t)lfs_init(lfs, cfg);
     if (err) {
         LFS_TRACE("lfs_mount -> %d", err);
         return err;

--- a/lfs.c
+++ b/lfs.c
@@ -1996,7 +1996,7 @@ int lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir) {
     return 0;
 }
 
-int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
+lfs_stag_t lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
     LFS_TRACE("lfs_dir_read(%p, %p, %p)",
             (void*)lfs, (void*)dir, (void*)info);
     memset(info, 0, sizeof(*info));
@@ -2023,7 +2023,7 @@ int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
                 return false;
             }
 
-            int err = lfs_dir_fetch(lfs, &dir->m, dir->m.tail);
+            lfs_stag_t err = lfs_dir_fetch(lfs, &dir->m, dir->m.tail);
             if (err) {
                 LFS_TRACE("lfs_dir_read -> %d", err);
                 return err;
@@ -2032,7 +2032,7 @@ int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
             dir->id = 0;
         }
 
-        int err = lfs_dir_getinfo(lfs, &dir->m, dir->id, info);
+        lfs_stag_t err = lfs_dir_getinfo(lfs, &dir->m, dir->id, info);
         if (err && err != LFS_ERR_NOENT) {
             LFS_TRACE("lfs_dir_read -> %d", err);
             return err;

--- a/lfs.c
+++ b/lfs.c
@@ -421,7 +421,7 @@ static lfs_stag_t lfs_fs_parent(lfs_t *lfs, const lfs_block_t dir[2],
         lfs_mdir_t *parent);
 static lfs_stag_t lfs_fs_relocate(lfs_t *lfs,
         const lfs_block_t oldpair[2], lfs_block_t newpair[2]);
-static int lfs_fs_forceconsistency(lfs_t *lfs);
+static lfs_stag_t lfs_fs_forceconsistency(lfs_t *lfs);
 static int lfs_deinit(lfs_t *lfs);
 #ifdef LFS_MIGRATE
 static int lfs1_traverse(lfs_t *lfs,
@@ -4045,8 +4045,8 @@ static lfs_stag_t lfs_fs_deorphan(lfs_t *lfs) {
     return 0;
 }
 
-static int lfs_fs_forceconsistency(lfs_t *lfs) {
-    int err = lfs_fs_demove(lfs);
+static lfs_stag_t lfs_fs_forceconsistency(lfs_t *lfs) {
+    lfs_stag_t err = lfs_fs_demove(lfs);
     if (err) {
         return err;
     }

--- a/lfs.c
+++ b/lfs.c
@@ -3973,7 +3973,7 @@ static lfs_stag_t lfs_fs_demove(lfs_t *lfs) {
     return 0;
 }
 
-static int lfs_fs_deorphan(lfs_t *lfs) {
+static lfs_stag_t lfs_fs_deorphan(lfs_t *lfs) {
     if (!lfs_gstate_hasorphans(&lfs->gstate)) {
         return 0;
     }
@@ -3984,7 +3984,7 @@ static int lfs_fs_deorphan(lfs_t *lfs) {
 
     // iterate over all directory directory entries
     while (!lfs_pair_isnull(dir.tail)) {
-        int err = lfs_dir_fetch(lfs, &dir, dir.tail);
+        lfs_stag_t err = lfs_dir_fetch(lfs, &dir, dir.tail);
         if (err) {
             return err;
         }
@@ -4025,7 +4025,7 @@ static int lfs_fs_deorphan(lfs_t *lfs) {
                         pair[0], pair[1]);
 
                 lfs_pair_tole32(pair);
-                err = lfs_dir_commit(lfs, &pdir, LFS_MKATTRS(
+                err = (lfs_stag_t)lfs_dir_commit(lfs, &pdir, LFS_MKATTRS(
                         {LFS_MKTAG(LFS_TYPE_SOFTTAIL, 0x3ff, 8), pair}));
                 lfs_pair_fromle32(pair);
                 if (err) {

--- a/lfs.c
+++ b/lfs.c
@@ -1844,10 +1844,10 @@ compact:
 
 
 /// Top level directory operations ///
-int lfs_mkdir(lfs_t *lfs, const char *path) {
+lfs_stag_t lfs_mkdir(lfs_t *lfs, const char *path) {
     LFS_TRACE("lfs_mkdir(%p, \"%s\")", (void*)lfs, path);
     // deorphan if we haven't yet, needed at most once after poweron
-    int err = lfs_fs_forceconsistency(lfs);
+    lfs_stag_t err = (lfs_stag_t)lfs_fs_forceconsistency(lfs);
     if (err) {
         LFS_TRACE("lfs_mkdir -> %d", err);
         return err;
@@ -1889,7 +1889,7 @@ int lfs_mkdir(lfs_t *lfs, const char *path) {
 
     // setup dir
     lfs_pair_tole32(pred.tail);
-    err = lfs_dir_commit(lfs, &dir, LFS_MKATTRS(
+    err = (lfs_stag_t)lfs_dir_commit(lfs, &dir, LFS_MKATTRS(
             {LFS_MKTAG(LFS_TYPE_SOFTTAIL, 0x3ff, 8), pred.tail}));
     lfs_pair_fromle32(pred.tail);
     if (err) {
@@ -1902,7 +1902,7 @@ int lfs_mkdir(lfs_t *lfs, const char *path) {
         // update tails, this creates a desync
         lfs_fs_preporphans(lfs, +1);
         lfs_pair_tole32(dir.pair);
-        err = lfs_dir_commit(lfs, &pred, LFS_MKATTRS(
+        err = (lfs_stag_t)lfs_dir_commit(lfs, &pred, LFS_MKATTRS(
                 {LFS_MKTAG(LFS_TYPE_SOFTTAIL, 0x3ff, 8), dir.pair}));
         lfs_pair_fromle32(dir.pair);
         if (err) {
@@ -1914,7 +1914,7 @@ int lfs_mkdir(lfs_t *lfs, const char *path) {
 
     // now insert into our parent block
     lfs_pair_tole32(dir.pair);
-    err = lfs_dir_commit(lfs, &cwd, LFS_MKATTRS(
+    err = (lfs_stag_t)lfs_dir_commit(lfs, &cwd, LFS_MKATTRS(
             {LFS_MKTAG(LFS_TYPE_CREATE, id, 0), NULL},
             {LFS_MKTAG(LFS_TYPE_DIR, id, nlen), path},
             {LFS_MKTAG(LFS_TYPE_DIRSTRUCT, id, 8), dir.pair},

--- a/lfs.c
+++ b/lfs.c
@@ -997,7 +997,7 @@ static lfs_stag_t lfs_dir_getgstate(lfs_t *lfs, const lfs_mdir_t *dir,
     return 0;
 }
 
-static int lfs_dir_getinfo(lfs_t *lfs, lfs_mdir_t *dir,
+static lfs_stag_t lfs_dir_getinfo(lfs_t *lfs, lfs_mdir_t *dir,
         uint16_t id, struct lfs_info *info) {
     if (id == 0x3ff) {
         // special case for root

--- a/lfs.c
+++ b/lfs.c
@@ -3319,7 +3319,7 @@ lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
     return size;
 }
 
-static int lfs_commitattr(lfs_t *lfs, const char *path,
+static lfs_stag_t lfs_commitattr(lfs_t *lfs, const char *path,
         uint8_t type, const void *buffer, lfs_size_t size) {
     lfs_mdir_t cwd;
     lfs_stag_t tag = lfs_dir_find(lfs, &cwd, &path, NULL);
@@ -3331,17 +3331,17 @@ static int lfs_commitattr(lfs_t *lfs, const char *path,
     if (id == 0x3ff) {
         // special case for root
         id = 0;
-        int err = lfs_dir_fetch(lfs, &cwd, lfs->root);
+        lfs_stag_t err = lfs_dir_fetch(lfs, &cwd, lfs->root);
         if (err) {
             return err;
         }
     }
 
-    return lfs_dir_commit(lfs, &cwd, LFS_MKATTRS(
+    return (lfs_stag_t)lfs_dir_commit(lfs, &cwd, LFS_MKATTRS(
             {LFS_MKTAG(LFS_TYPE_USERATTR + type, id, size), buffer}));
 }
 
-int lfs_setattr(lfs_t *lfs, const char *path,
+lfs_stag_t lfs_setattr(lfs_t *lfs, const char *path,
         uint8_t type, const void *buffer, lfs_size_t size) {
     LFS_TRACE("lfs_setattr(%p, \"%s\", %"PRIu8", %p, %"PRIu32")",
             (void*)lfs, path, type, buffer, size);
@@ -3350,14 +3350,14 @@ int lfs_setattr(lfs_t *lfs, const char *path,
         return LFS_ERR_NOSPC;
     }
 
-    int err = lfs_commitattr(lfs, path, type, buffer, size);
+    lfs_stag_t err = lfs_commitattr(lfs, path, type, buffer, size);
     LFS_TRACE("lfs_setattr -> %d", err);
     return err;
 }
 
-int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type) {
+lfs_stag_t lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type) {
     LFS_TRACE("lfs_removeattr(%p, \"%s\", %"PRIu8")", (void*)lfs, path, type);
-    int err = lfs_commitattr(lfs, path, type, NULL, 0x3ff);
+    lfs_stag_t err = lfs_commitattr(lfs, path, type, NULL, 0x3ff);
     LFS_TRACE("lfs_removeattr -> %d", err);
     return err;
 }

--- a/lfs.c
+++ b/lfs.c
@@ -415,7 +415,7 @@ static lfs_ssize_t lfs_file_flush(lfs_t *lfs, lfs_file_t *file);
 static void lfs_fs_preporphans(lfs_t *lfs, int8_t orphans);
 static void lfs_fs_prepmove(lfs_t *lfs,
         uint16_t id, const lfs_block_t pair[2]);
-static int lfs_fs_pred(lfs_t *lfs, const lfs_block_t dir[2],
+static lfs_stag_t lfs_fs_pred(lfs_t *lfs, const lfs_block_t dir[2],
         lfs_mdir_t *pdir);
 static lfs_stag_t lfs_fs_parent(lfs_t *lfs, const lfs_block_t dir[2],
         lfs_mdir_t *parent);
@@ -3807,7 +3807,7 @@ lfs_stag_t lfs_fs_traverse(lfs_t *lfs,
     return 0;
 }
 
-static int lfs_fs_pred(lfs_t *lfs,
+static lfs_stag_t lfs_fs_pred(lfs_t *lfs,
         const lfs_block_t pair[2], lfs_mdir_t *pdir) {
     // iterate over all directory directory entries
     pdir->tail[0] = 0;
@@ -3817,7 +3817,7 @@ static int lfs_fs_pred(lfs_t *lfs,
             return 0;
         }
 
-        int err = lfs_dir_fetch(lfs, pdir, pdir->tail);
+        lfs_stag_t err = lfs_dir_fetch(lfs, pdir, pdir->tail);
         if (err) {
             return err;
         }

--- a/lfs.c
+++ b/lfs.c
@@ -513,7 +513,7 @@ static lfs_stag_t lfs_dir_getslice(lfs_t *lfs, const lfs_mdir_t *dir,
                 NULL, &lfs->rcache, sizeof(ntag),
                 dir->pair[0], off, &ntag, sizeof(ntag));
         if (err) {
-            return err;
+            return (lfs_stag_t)err;
         }
 
         ntag = (lfs_frombe32(ntag) ^ tag) & 0x7fffffff;
@@ -524,7 +524,7 @@ static lfs_stag_t lfs_dir_getslice(lfs_t *lfs, const lfs_mdir_t *dir,
             if (tag == (LFS_MKTAG(LFS_TYPE_CREATE, 0, 0) |
                     (LFS_MKTAG(0, 0x3ff, 0) & (gtag - gdiff)))) {
                 // found where we were created
-                return LFS_ERR_NOENT;
+                return (lfs_stag_t)LFS_ERR_NOENT;
             }
 
             // move around splices
@@ -533,7 +533,7 @@ static lfs_stag_t lfs_dir_getslice(lfs_t *lfs, const lfs_mdir_t *dir,
 
         if ((gmask & tag) == (gmask & (gtag - gdiff))) {
             if (lfs_tag_isdelete(tag)) {
-                return LFS_ERR_NOENT;
+                return (lfs_stag_t)LFS_ERR_NOENT;
             }
 
             lfs_size_t diff = lfs_min(lfs_tag_size(tag), gsize);
@@ -541,7 +541,7 @@ static lfs_stag_t lfs_dir_getslice(lfs_t *lfs, const lfs_mdir_t *dir,
                     NULL, &lfs->rcache, diff,
                     dir->pair[0], off+sizeof(tag)+goff, gbuffer, diff);
             if (err) {
-                return err;
+                return (lfs_stag_t)err;
             }
 
             memset((uint8_t*)gbuffer + diff, 0, gsize - diff);
@@ -550,7 +550,7 @@ static lfs_stag_t lfs_dir_getslice(lfs_t *lfs, const lfs_mdir_t *dir,
         }
     }
 
-    return LFS_ERR_NOENT;
+    return (lfs_stag_t)LFS_ERR_NOENT;
 }
 
 static lfs_stag_t lfs_dir_get(lfs_t *lfs, const lfs_mdir_t *dir,

--- a/lfs.c
+++ b/lfs.c
@@ -2735,7 +2735,7 @@ lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
 
     if (file->flags & LFS_F_WRITING) {
         // flush out any writes
-        int err = lfs_file_flush(lfs, file);
+        lfs_ssize_t err = lfs_file_flush(lfs, file);
         if (err) {
             LFS_TRACE("lfs_file_read -> %"PRId32, err);
             return err;
@@ -2756,7 +2756,7 @@ lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
         if (!(file->flags & LFS_F_READING) ||
                 file->off == lfs->cfg->block_size) {
             if (!(file->flags & LFS_F_INLINE)) {
-                int err = lfs_ctz_find(lfs, NULL, &file->cache,
+                lfs_ssize_t err = (lfs_ssize_t)lfs_ctz_find(lfs, NULL, &file->cache,
                         file->ctz.head, file->ctz.size,
                         file->pos, &file->block, &file->off);
                 if (err) {
@@ -2774,17 +2774,17 @@ lfs_ssize_t lfs_file_read(lfs_t *lfs, lfs_file_t *file,
         // read as much as we can in current block
         lfs_size_t diff = lfs_min(nsize, lfs->cfg->block_size - file->off);
         if (file->flags & LFS_F_INLINE) {
-            int err = lfs_dir_getread(lfs, &file->m,
+            lfs_stag_t err = lfs_dir_getread(lfs, &file->m,
                     NULL, &file->cache, lfs->cfg->block_size,
                     LFS_MKTAG(0xfff, 0x1ff, 0),
                     LFS_MKTAG(LFS_TYPE_INLINESTRUCT, file->id, 0),
                     file->off, data, diff);
             if (err) {
                 LFS_TRACE("lfs_file_read -> %"PRId32, err);
-                return err;
+                return (lfs_ssize_t)err;
             }
         } else {
-            int err = lfs_bd_read(lfs,
+            lfs_ssize_t err = (lfs_ssize_t)lfs_bd_read(lfs,
                     NULL, &file->cache, lfs->cfg->block_size,
                     file->block, file->off, data, diff);
             if (err) {

--- a/lfs.c
+++ b/lfs.c
@@ -3717,7 +3717,7 @@ int lfs_unmount(lfs_t *lfs) {
 
 
 /// Filesystem filesystem operations ///
-int lfs_fs_traverse(lfs_t *lfs,
+lfs_stag_t lfs_fs_traverse(lfs_t *lfs,
         int (*cb)(void *data, lfs_block_t block), void *data) {
     LFS_TRACE("lfs_fs_traverse(%p, %p, %p)",
             (void*)lfs, (void*)(uintptr_t)cb, data);
@@ -3730,7 +3730,7 @@ int lfs_fs_traverse(lfs_t *lfs,
         int err = lfs1_traverse(lfs, cb, data);
         if (err) {
             LFS_TRACE("lfs_fs_traverse -> %d", err);
-            return err;
+            return (lfs_stag_t)err;
         }
 
         dir.tail[0] = lfs->root[0];
@@ -3743,12 +3743,12 @@ int lfs_fs_traverse(lfs_t *lfs,
             int err = cb(data, dir.tail[i]);
             if (err) {
                 LFS_TRACE("lfs_fs_traverse -> %d", err);
-                return err;
+                return (lfs_stag_t)err;
             }
         }
 
         // iterate through ids in directory
-        int err = lfs_dir_fetch(lfs, &dir, dir.tail);
+        lfs_stag_t err = lfs_dir_fetch(lfs, &dir, dir.tail);
         if (err) {
             LFS_TRACE("lfs_fs_traverse -> %d", err);
             return err;
@@ -3772,7 +3772,7 @@ int lfs_fs_traverse(lfs_t *lfs,
                         ctz.head, ctz.size, cb, data);
                 if (err) {
                     LFS_TRACE("lfs_fs_traverse -> %d", err);
-                    return err;
+                    return (lfs_stag_t)err;
                 }
             }
         }
@@ -3789,7 +3789,7 @@ int lfs_fs_traverse(lfs_t *lfs,
                     f->ctz.head, f->ctz.size, cb, data);
             if (err) {
                 LFS_TRACE("lfs_fs_traverse -> %d", err);
-                return err;
+                return (lfs_stag_t)err;
             }
         }
 
@@ -3798,7 +3798,7 @@ int lfs_fs_traverse(lfs_t *lfs,
                     f->block, f->pos, cb, data);
             if (err) {
                 LFS_TRACE("lfs_fs_traverse -> %d", err);
-                return err;
+                return (lfs_stag_t)err;
             }
         }
     }

--- a/lfs.c
+++ b/lfs.c
@@ -3488,7 +3488,7 @@ static int lfs_deinit(lfs_t *lfs) {
     return 0;
 }
 
-int lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
+lfs_stag_t lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
     LFS_TRACE("lfs_format(%p, %p {.context=%p, "
                 ".read=%p, .prog=%p, .erase=%p, .sync=%p, "
                 ".read_size=%"PRIu32", .prog_size=%"PRIu32", "
@@ -3505,9 +3505,9 @@ int lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
             cfg->block_cycles, cfg->cache_size, cfg->lookahead_size,
             cfg->read_buffer, cfg->prog_buffer, cfg->lookahead_buffer,
             cfg->name_max, cfg->file_max, cfg->attr_max);
-    int err = 0;
+    lfs_stag_t err = 0;
     {
-        err = lfs_init(lfs, cfg);
+        err = (lfs_stag_t)lfs_init(lfs, cfg);
         if (err) {
             LFS_TRACE("lfs_format -> %d", err);
             return err;
@@ -3539,7 +3539,7 @@ int lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
         };
 
         lfs_superblock_tole32(&superblock);
-        err = lfs_dir_commit(lfs, &root, LFS_MKATTRS(
+        err = (lfs_stag_t)lfs_dir_commit(lfs, &root, LFS_MKATTRS(
                 {LFS_MKTAG(LFS_TYPE_CREATE, 0, 0), NULL},
                 {LFS_MKTAG(LFS_TYPE_SUPERBLOCK, 0, 8), "littlefs"},
                 {LFS_MKTAG(LFS_TYPE_INLINESTRUCT, 0, sizeof(superblock)),
@@ -3557,7 +3557,7 @@ int lfs_format(lfs_t *lfs, const struct lfs_config *cfg) {
         // force compaction to prevent accidentally mounting any
         // older version of littlefs that may live on disk
         root.erased = false;
-        err = lfs_dir_commit(lfs, &root, NULL, 0);
+        err = (lfs_stag_t)lfs_dir_commit(lfs, &root, NULL, 0);
         if (err) {
             goto cleanup;
         }

--- a/lfs.c
+++ b/lfs.c
@@ -1931,7 +1931,7 @@ int lfs_mkdir(lfs_t *lfs, const char *path) {
     return 0;
 }
 
-int lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
+lfs_stag_t lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
     LFS_TRACE("lfs_dir_open(%p, %p, \"%s\")", (void*)lfs, (void*)dir, path);
     lfs_stag_t tag = lfs_dir_find(lfs, &dir->m, &path, NULL);
     if (tag < 0) {
@@ -1941,7 +1941,7 @@ int lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
 
     if (lfs_tag_type3(tag) != LFS_TYPE_DIR) {
         LFS_TRACE("lfs_dir_open -> %d", LFS_ERR_NOTDIR);
-        return LFS_ERR_NOTDIR;
+        return (lfs_stag_t)LFS_ERR_NOTDIR;
     }
 
     lfs_block_t pair[2];
@@ -1964,7 +1964,7 @@ int lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
     int err = lfs_dir_fetch(lfs, &dir->m, pair);
     if (err) {
         LFS_TRACE("lfs_dir_open -> %d", err);
-        return err;
+        return (lfs_stag_t)err;
     }
 
     // setup entry

--- a/lfs.c
+++ b/lfs.c
@@ -1738,7 +1738,7 @@ static lfs_ssize_t lfs_dir_commit(lfs_t *lfs, lfs_mdir_t *dir,
 
         // traverse attrs that need to be written out
         lfs_pair_tole32(dir->tail);
-        int err = lfs_dir_traverse(lfs,
+        lfs_ssize_t err = (lfs_ssize_t)lfs_dir_traverse(lfs,
                 dir, dir->off, dir->etag, attrs, attrcount, false,
                 0, 0, 0, 0, 0,
                 lfs_dir_commit_commit, &(struct lfs_dir_commit_commit){
@@ -1753,13 +1753,13 @@ static lfs_ssize_t lfs_dir_commit(lfs_t *lfs, lfs_mdir_t *dir,
 
         // commit any global diffs if we have any
         if (!lfs_gstate_iszero(&lfs->gdelta)) {
-            err = lfs_dir_getgstate(lfs, dir, &lfs->gdelta);
+            err = (lfs_ssize_t)lfs_dir_getgstate(lfs, dir, &lfs->gdelta);
             if (err) {
                 return err;
             }
 
             lfs_gstate_tole32(&lfs->gdelta);
-            err = lfs_dir_commitattr(lfs, &commit,
+            err = (lfs_ssize_t)lfs_dir_commitattr(lfs, &commit,
                     LFS_MKTAG(LFS_TYPE_MOVESTATE, 0x3ff,
                         sizeof(lfs->gdelta)), &lfs->gdelta);
             lfs_gstate_fromle32(&lfs->gdelta);
@@ -1772,7 +1772,7 @@ static lfs_ssize_t lfs_dir_commit(lfs_t *lfs, lfs_mdir_t *dir,
         }
 
         // finalize commit with the crc
-        err = lfs_dir_commitcrc(lfs, &commit);
+        err = (lfs_ssize_t)lfs_dir_commitcrc(lfs, &commit);
         if (err) {
             if (err == LFS_ERR_NOSPC || err == LFS_ERR_CORRUPT) {
                 goto compact;

--- a/lfs.c
+++ b/lfs.c
@@ -2093,10 +2093,10 @@ lfs_soff_t lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir) {
     return dir->pos;
 }
 
-int lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir) {
+lfs_stag_t lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir) {
     LFS_TRACE("lfs_dir_rewind(%p, %p)", (void*)lfs, (void*)dir);
     // reload the head dir
-    int err = lfs_dir_fetch(lfs, &dir->m, dir->head);
+    lfs_stag_t err = lfs_dir_fetch(lfs, &dir->m, dir->head);
     if (err) {
         LFS_TRACE("lfs_dir_rewind -> %d", err);
         return err;

--- a/lfs.c
+++ b/lfs.c
@@ -4069,7 +4069,7 @@ static int lfs_fs_size_count(void *p, lfs_block_t block) {
 lfs_ssize_t lfs_fs_size(lfs_t *lfs) {
     LFS_TRACE("lfs_fs_size(%p)", (void*)lfs);
     lfs_size_t size = 0;
-    int err = lfs_fs_traverse(lfs, lfs_fs_size_count, &size);
+    lfs_ssize_t err = (lfs_ssize_t)lfs_fs_traverse(lfs, lfs_fs_size_count, &size);
     if (err) {
         LFS_TRACE("lfs_fs_size -> %"PRId32, err);
         return err;

--- a/lfs.c
+++ b/lfs.c
@@ -2160,21 +2160,21 @@ static int lfs_ctz_find(lfs_t *lfs,
     return 0;
 }
 
-static int lfs_ctz_extend(lfs_t *lfs,
+static lfs_stag_t lfs_ctz_extend(lfs_t *lfs,
         lfs_cache_t *pcache, lfs_cache_t *rcache,
         lfs_block_t head, lfs_size_t size,
         lfs_block_t *block, lfs_off_t *off) {
     while (true) {
         // go ahead and grab a block
         lfs_block_t nblock;
-        int err = lfs_alloc(lfs, &nblock);
+        lfs_stag_t err = lfs_alloc(lfs, &nblock);
         if (err) {
             return err;
         }
         LFS_ASSERT(nblock >= 2 && nblock <= lfs->cfg->block_count);
 
         {
-            err = lfs_bd_erase(lfs, nblock);
+            err = (lfs_stag_t)lfs_bd_erase(lfs, nblock);
             if (err) {
                 if (err == LFS_ERR_CORRUPT) {
                     goto relocate;
@@ -2196,14 +2196,14 @@ static int lfs_ctz_extend(lfs_t *lfs,
             if (size != lfs->cfg->block_size) {
                 for (lfs_off_t i = 0; i < size; i++) {
                     uint8_t data;
-                    err = lfs_bd_read(lfs,
+                    err = (lfs_stag_t)lfs_bd_read(lfs,
                             NULL, rcache, size-i,
                             head, i, &data, 1);
                     if (err) {
                         return err;
                     }
 
-                    err = lfs_bd_prog(lfs,
+                    err = (lfs_stag_t)lfs_bd_prog(lfs,
                             pcache, rcache, true,
                             nblock, i, &data, 1);
                     if (err) {
@@ -2225,7 +2225,7 @@ static int lfs_ctz_extend(lfs_t *lfs,
 
             for (lfs_off_t i = 0; i < skips; i++) {
                 head = lfs_tole32(head);
-                err = lfs_bd_prog(lfs, pcache, rcache, true,
+                err = (lfs_stag_t)lfs_bd_prog(lfs, pcache, rcache, true,
                         nblock, 4*i, &head, 4);
                 head = lfs_fromle32(head);
                 if (err) {
@@ -2236,7 +2236,7 @@ static int lfs_ctz_extend(lfs_t *lfs,
                 }
 
                 if (i != skips-1) {
-                    err = lfs_bd_read(lfs,
+                    err = (lfs_stag_t)lfs_bd_read(lfs,
                             NULL, rcache, sizeof(head),
                             head, 4*i, &head, sizeof(head));
                     head = lfs_fromle32(head);

--- a/lfs.c
+++ b/lfs.c
@@ -1318,10 +1318,10 @@ static int lfs_dir_commitcrc(lfs_t *lfs, struct lfs_commit *commit) {
     return 0;
 }
 
-static int lfs_dir_alloc(lfs_t *lfs, lfs_mdir_t *dir) {
+static lfs_stag_t lfs_dir_alloc(lfs_t *lfs, lfs_mdir_t *dir) {
     // allocate pair of dir blocks (backwards, so we write block 1 first)
     for (int i = 0; i < 2; i++) {
-        int err = lfs_alloc(lfs, &dir->pair[(i+1)%2]);
+        lfs_stag_t err = lfs_alloc(lfs, &dir->pair[(i+1)%2]);
         if (err) {
             return err;
         }
@@ -1334,7 +1334,7 @@ static int lfs_dir_alloc(lfs_t *lfs, lfs_mdir_t *dir) {
             dir->pair[0], 0, &dir->rev, sizeof(dir->rev));
     dir->rev = lfs_fromle32(dir->rev);
     if (err && err != LFS_ERR_CORRUPT) {
-        return err;
+        return (lfs_stag_t)err;
     }
 
     // make sure we don't immediately evict

--- a/lfs.c
+++ b/lfs.c
@@ -1061,7 +1061,7 @@ static int lfs_dir_find_match(void *data,
     return LFS_CMP_EQ;
 }
 
-static int lfs_dir_find(lfs_t *lfs, lfs_mdir_t *dir,
+static lfs_stag_t lfs_dir_find(lfs_t *lfs, lfs_mdir_t *dir,
         const char **path, uint16_t *id) {
     // we reduce path to a single name if we can find it
     const char *name = *path;

--- a/lfs.c
+++ b/lfs.c
@@ -1961,10 +1961,10 @@ lfs_stag_t lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path) {
     }
 
     // fetch first pair
-    int err = lfs_dir_fetch(lfs, &dir->m, pair);
+    lfs_stag_t err = lfs_dir_fetch(lfs, &dir->m, pair);
     if (err) {
         LFS_TRACE("lfs_dir_open -> %d", err);
-        return (lfs_stag_t)err;
+        return err;
     }
 
     // setup entry

--- a/lfs.c
+++ b/lfs.c
@@ -979,7 +979,7 @@ static lfs_stag_t lfs_dir_fetch(lfs_t *lfs,
     return lfs_dir_fetchmatch(lfs, dir, pair, -1, 0, NULL, NULL, NULL);
 }
 
-static int lfs_dir_getgstate(lfs_t *lfs, const lfs_mdir_t *dir,
+static lfs_stag_t lfs_dir_getgstate(lfs_t *lfs, const lfs_mdir_t *dir,
         struct lfs_gstate *gstate) {
     struct lfs_gstate temp;
     lfs_stag_t res = lfs_dir_get(lfs, dir, LFS_MKTAG(0x7ff, 0, 0),

--- a/lfs.c
+++ b/lfs.c
@@ -3286,7 +3286,7 @@ lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
     lfs_stag_t tag = lfs_dir_find(lfs, &cwd, &path, NULL);
     if (tag < 0) {
         LFS_TRACE("lfs_getattr -> %"PRId32, tag);
-        return tag;
+        return (lfs_ssize_t)tag;
     }
 
     uint16_t id = lfs_tag_id(tag);
@@ -3296,7 +3296,7 @@ lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
         int err = lfs_dir_fetch(lfs, &cwd, lfs->root);
         if (err) {
             LFS_TRACE("lfs_getattr -> %"PRId32, err);
-            return err;
+            return (lfs_ssize_t)err;
         }
     }
 
@@ -3307,11 +3307,11 @@ lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
     if (tag < 0) {
         if (tag == LFS_ERR_NOENT) {
             LFS_TRACE("lfs_getattr -> %"PRId32, LFS_ERR_NOATTR);
-            return LFS_ERR_NOATTR;
+            return (lfs_ssize_t)LFS_ERR_NOATTR;
         }
 
         LFS_TRACE("lfs_getattr -> %"PRId32, tag);
-        return tag;
+        return (lfs_ssize_t)tag;
     }
 
     size = lfs_tag_size(tag);

--- a/lfs.c
+++ b/lfs.c
@@ -2112,7 +2112,7 @@ int lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir) {
 
 
 /// File index list operations ///
-static int lfs_ctz_index(lfs_t *lfs, lfs_off_t *off) {
+static lfs_off_t lfs_ctz_index(lfs_t *lfs, lfs_off_t *off) {
     lfs_off_t size = *off;
     lfs_off_t b = lfs->cfg->block_size - 2*4;
     lfs_off_t i = size / b;

--- a/lfs.c
+++ b/lfs.c
@@ -2470,11 +2470,11 @@ lfs_stag_t lfs_file_open(lfs_t *lfs, lfs_file_t *file,
     return err;
 }
 
-int lfs_file_close(lfs_t *lfs, lfs_file_t *file) {
+lfs_ssize_t lfs_file_close(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_close(%p, %p)", (void*)lfs, (void*)file);
     LFS_ASSERT(file->flags & LFS_F_OPENED);
 
-    int err = lfs_file_sync(lfs, file);
+    lfs_ssize_t err = lfs_file_sync(lfs, file);
 
     // remove from list of mdirs
     for (struct lfs_mlist **p = &lfs->mlist; *p; p = &(*p)->next) {

--- a/lfs.c
+++ b/lfs.c
@@ -3069,7 +3069,7 @@ lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
 
 
 /// General fs operations ///
-int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info) {
+lfs_stag_t lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info) {
     LFS_TRACE("lfs_stat(%p, \"%s\", %p)", (void*)lfs, path, (void*)info);
     lfs_mdir_t cwd;
     lfs_stag_t tag = lfs_dir_find(lfs, &cwd, &path, NULL);
@@ -3078,7 +3078,7 @@ int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info) {
         return tag;
     }
 
-    int err = lfs_dir_getinfo(lfs, &cwd, lfs_tag_id(tag), info);
+    lfs_stag_t err = (lfs_stag_t)lfs_dir_getinfo(lfs, &cwd, lfs_tag_id(tag), info);
     LFS_TRACE("lfs_stat -> %d", err);
     return err;
 }

--- a/lfs.c
+++ b/lfs.c
@@ -972,7 +972,7 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
     return LFS_ERR_CORRUPT;
 }
 
-static int lfs_dir_fetch(lfs_t *lfs,
+static lfs_stag_t lfs_dir_fetch(lfs_t *lfs,
         lfs_mdir_t *dir, const lfs_block_t pair[2]) {
     // note, mask=-1, tag=0 can never match a tag since this
     // pattern has the invalid bit set

--- a/lfs.c
+++ b/lfs.c
@@ -3041,7 +3041,7 @@ lfs_soff_t lfs_file_tell(lfs_t *lfs, lfs_file_t *file) {
     return file->pos;
 }
 
-int lfs_file_rewind(lfs_t *lfs, lfs_file_t *file) {
+lfs_soff_t lfs_file_rewind(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_rewind(%p, %p)", (void*)lfs, (void*)file);
     lfs_soff_t res = lfs_file_seek(lfs, file, 0, LFS_SEEK_SET);
     if (res < 0) {
@@ -3060,10 +3060,10 @@ lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file) {
     if (file->flags & LFS_F_WRITING) {
         LFS_TRACE("lfs_file_size -> %"PRId32,
                 lfs_max(file->pos, file->ctz.size));
-        return lfs_max(file->pos, file->ctz.size);
+        return (lfs_soff_t)lfs_max(file->pos, file->ctz.size);
     } else {
         LFS_TRACE("lfs_file_size -> %"PRId32, file->ctz.size);
-        return file->ctz.size;
+        return (lfs_soff_t)file->ctz.size;
     }
 }
 

--- a/lfs.c
+++ b/lfs.c
@@ -2657,12 +2657,12 @@ relocate:
     return 0;
 }
 
-int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
+lfs_ssize_t lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
     LFS_TRACE("lfs_file_sync(%p, %p)", (void*)lfs, (void*)file);
     LFS_ASSERT(file->flags & LFS_F_OPENED);
 
     while (true) {
-        int err = lfs_file_flush(lfs, file);
+        lfs_ssize_t err = lfs_file_flush(lfs, file);
         if (err) {
             file->flags |= LFS_F_ERRED;
             LFS_TRACE("lfs_file_sync -> %d", err);
@@ -2693,7 +2693,7 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
             }
 
             // commit file data and attributes
-            err = lfs_dir_commit(lfs, &file->m, LFS_MKATTRS(
+            err = (lfs_ssize_t)lfs_dir_commit(lfs, &file->m, LFS_MKATTRS(
                     {LFS_MKTAG(type, file->id, size), buffer},
                     {LFS_MKTAG(LFS_FROM_USERATTRS, file->id,
                         file->cfg->attr_count), file->cfg->attrs}));
@@ -2714,7 +2714,7 @@ int lfs_file_sync(lfs_t *lfs, lfs_file_t *file) {
 
 relocate:
         // inline file doesn't fit anymore
-        err = lfs_file_outline(lfs, file);
+        err = (lfs_ssize_t)lfs_file_outline(lfs, file);
         if (err) {
             file->flags |= LFS_F_ERRED;
             LFS_TRACE("lfs_file_sync -> %d", err);

--- a/lfs.c
+++ b/lfs.c
@@ -2306,7 +2306,7 @@ static int lfs_ctz_traverse(lfs_t *lfs,
 
 
 /// Top level file operations ///
-int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
+lfs_stag_t lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags,
         const struct lfs_file_config *cfg) {
     LFS_TRACE("lfs_file_opencfg(%p, %p, \"%s\", %x, %p {"
@@ -2319,12 +2319,12 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
         int err = lfs_fs_forceconsistency(lfs);
         if (err) {
             LFS_TRACE("lfs_file_opencfg -> %d", err);
-            return err;
+            return (lfs_stag_t)err;
         }
     }
 
     // setup simple file details
-    int err;
+    lfs_stag_t err;
     file->cfg = cfg;
     file->flags = flags | LFS_F_OPENED;
     file->pos = 0;
@@ -2357,7 +2357,7 @@ int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
         }
 
         // get next slot and create entry to remember name
-        err = lfs_dir_commit(lfs, &file->m, LFS_MKATTRS(
+        err = (lfs_stag_t)lfs_dir_commit(lfs, &file->m, LFS_MKATTRS(
                 {LFS_MKTAG(LFS_TYPE_CREATE, file->id, 0), NULL},
                 {LFS_MKTAG(LFS_TYPE_REG, file->id, nlen), path},
                 {LFS_MKTAG(LFS_TYPE_INLINESTRUCT, file->id, 0), NULL}));

--- a/lfs.c
+++ b/lfs.c
@@ -441,7 +441,7 @@ static int lfs_alloc_lookahead(void *p, lfs_block_t block) {
     return 0;
 }
 
-static int lfs_alloc(lfs_t *lfs, lfs_block_t *block) {
+static lfs_stag_t lfs_alloc(lfs_t *lfs, lfs_block_t *block) {
     while (true) {
         while (lfs->free.i != lfs->free.size) {
             lfs_block_t off = lfs->free.i;
@@ -479,7 +479,7 @@ static int lfs_alloc(lfs_t *lfs, lfs_block_t *block) {
 
         // find mask of free blocks from tree
         memset(lfs->free.buffer, 0, lfs->cfg->lookahead_size);
-        int err = lfs_fs_traverse(lfs, lfs_alloc_lookahead, lfs);
+        lfs_stag_t err = lfs_fs_traverse(lfs, lfs_alloc_lookahead, lfs);
         if (err) {
             return err;
         }

--- a/lfs.c
+++ b/lfs.c
@@ -260,7 +260,6 @@ static inline void lfs_pair_tole32(lfs_block_t pair[2]) {
 
 // operations on 32-bit entry tags
 typedef uint32_t lfs_tag_t;
-typedef int32_t lfs_stag_t;
 
 #define LFS_MKTAG(type, id, size) \
     (((lfs_tag_t)(type) << 20) | ((lfs_tag_t)(id) << 10) | (lfs_tag_t)(size))

--- a/lfs.c
+++ b/lfs.c
@@ -2460,12 +2460,12 @@ cleanup:
     return err;
 }
 
-int lfs_file_open(lfs_t *lfs, lfs_file_t *file,
+lfs_stag_t lfs_file_open(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags) {
     LFS_TRACE("lfs_file_open(%p, %p, \"%s\", %x)",
             (void*)lfs, (void*)file, path, flags);
     static const struct lfs_file_config defaults = {0};
-    int err = lfs_file_opencfg(lfs, file, path, flags, &defaults);
+    lfs_stag_t err = lfs_file_opencfg(lfs, file, path, flags, &defaults);
     LFS_TRACE("lfs_file_open -> %d", err);
     return err;
 }

--- a/lfs.c
+++ b/lfs.c
@@ -2049,11 +2049,11 @@ lfs_stag_t lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info) {
     return true;
 }
 
-int lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
+lfs_stag_t lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
     LFS_TRACE("lfs_dir_seek(%p, %p, %"PRIu32")",
             (void*)lfs, (void*)dir, off);
     // simply walk from head dir
-    int err = lfs_dir_rewind(lfs, dir);
+    lfs_stag_t err = lfs_dir_rewind(lfs, dir);
     if (err) {
         LFS_TRACE("lfs_dir_seek -> %d", err);
         return err;

--- a/lfs.c
+++ b/lfs.c
@@ -560,13 +560,13 @@ static lfs_stag_t lfs_dir_get(lfs_t *lfs, const lfs_mdir_t *dir,
             0, buffer, lfs_tag_size(gtag));
 }
 
-static int lfs_dir_getread(lfs_t *lfs, const lfs_mdir_t *dir,
+static lfs_stag_t lfs_dir_getread(lfs_t *lfs, const lfs_mdir_t *dir,
         const lfs_cache_t *pcache, lfs_cache_t *rcache, lfs_size_t hint,
         lfs_tag_t gmask, lfs_tag_t gtag,
         lfs_off_t off, void *buffer, lfs_size_t size) {
     uint8_t *data = buffer;
     if (off+size > lfs->cfg->block_size) {
-        return LFS_ERR_CORRUPT;
+        return (lfs_stag_t)LFS_ERR_CORRUPT;
     }
 
     while (size > 0) {
@@ -611,7 +611,7 @@ static int lfs_dir_getread(lfs_t *lfs, const lfs_mdir_t *dir,
         rcache->off = lfs_aligndown(off, lfs->cfg->read_size);
         rcache->size = lfs_min(lfs_alignup(off+hint, lfs->cfg->read_size),
                 lfs->cfg->cache_size);
-        int err = lfs_dir_getslice(lfs, dir, gmask, gtag,
+        lfs_stag_t err = lfs_dir_getslice(lfs, dir, gmask, gtag,
                 rcache->off, rcache->buffer, rcache->size);
         if (err < 0) {
             return err;

--- a/lfs.c
+++ b/lfs.c
@@ -767,7 +767,7 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
                 pair[i], 0, &revs[i], sizeof(revs[i]));
         revs[i] = lfs_fromle32(revs[i]);
         if (err && err != LFS_ERR_CORRUPT) {
-            return err;
+            return (lfs_stag_t)err;
         }
 
         if (err != LFS_ERR_CORRUPT &&
@@ -808,7 +808,7 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
                     dir->erased = false;
                     break;
                 }
-                return err;
+                return (lfs_stag_t)err;
             }
 
             crc = lfs_crc(crc, &tag, sizeof(tag));
@@ -835,7 +835,7 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
                         dir->erased = false;
                         break;
                     }
-                    return err;
+                    return (lfs_stag_t)err;
                 }
                 dcrc = lfs_fromle32(dcrc);
 
@@ -876,7 +876,7 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
                         dir->erased = false;
                         break;
                     }
-                    return err;
+                    return (lfs_stag_t)err;
                 }
 
                 crc = lfs_crc(crc, &dat, 1);
@@ -922,7 +922,7 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
                         dir->erased = false;
                         break;
                     }
-                    return res;
+                    return (lfs_stag_t)res;
                 }
 
                 if (res == LFS_CMP_EQ) {

--- a/lfs.h
+++ b/lfs.h
@@ -442,7 +442,7 @@ lfs_stag_t lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath);
 //
 // Fills out the info structure, based on the specified file or directory.
 // Returns a negative error code on failure.
-int lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info);
+lfs_stag_t lfs_stat(lfs_t *lfs, const char *path, struct lfs_info *info);
 
 // Get a custom attribute
 //

--- a/lfs.h
+++ b/lfs.h
@@ -428,7 +428,7 @@ int lfs_unmount(lfs_t *lfs);
 //
 // If removing a directory, the directory must be empty.
 // Returns a negative error code on failure.
-int lfs_remove(lfs_t *lfs, const char *path);
+lfs_stag_t lfs_remove(lfs_t *lfs, const char *path);
 
 // Rename or move a file or directory
 //

--- a/lfs.h
+++ b/lfs.h
@@ -414,7 +414,7 @@ lfs_stag_t lfs_format(lfs_t *lfs, const struct lfs_config *config);
 // be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
-int lfs_mount(lfs_t *lfs, const struct lfs_config *config);
+lfs_stag_t lfs_mount(lfs_t *lfs, const struct lfs_config *config);
 
 // Unmounts a littlefs
 //

--- a/lfs.h
+++ b/lfs.h
@@ -595,7 +595,7 @@ lfs_stag_t lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
 // an absolute offset in the directory seek.
 //
 // Returns a negative error code on failure.
-int lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
+lfs_stag_t lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off);
 
 // Return the position of the directory
 //

--- a/lfs.h
+++ b/lfs.h
@@ -587,7 +587,7 @@ int lfs_dir_close(lfs_t *lfs, lfs_dir_t *dir);
 // Fills out the info structure, based on the specified file or directory.
 // Returns a positive value on success, 0 at the end of directory,
 // or a negative error code on failure.
-int lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
+lfs_stag_t lfs_dir_read(lfs_t *lfs, lfs_dir_t *dir, struct lfs_info *info);
 
 // Change the position of the directory
 //

--- a/lfs.h
+++ b/lfs.h
@@ -466,7 +466,7 @@ lfs_ssize_t lfs_getattr(lfs_t *lfs, const char *path,
 // implicitly created.
 //
 // Returns a negative error code on failure.
-int lfs_setattr(lfs_t *lfs, const char *path,
+lfs_stag_t lfs_setattr(lfs_t *lfs, const char *path,
         uint8_t type, const void *buffer, lfs_size_t size);
 
 // Removes a custom attribute
@@ -474,7 +474,7 @@ int lfs_setattr(lfs_t *lfs, const char *path,
 // If an attribute is not found, nothing happens.
 //
 // Returns a negative error code on failure.
-int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type);
+lfs_stag_t lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type);
 
 
 /// File operations ///

--- a/lfs.h
+++ b/lfs.h
@@ -514,7 +514,7 @@ int lfs_file_close(lfs_t *lfs, lfs_file_t *file);
 //
 // Any pending writes are written out to storage.
 // Returns a negative error code on failure.
-int lfs_file_sync(lfs_t *lfs, lfs_file_t *file);
+lfs_ssize_t lfs_file_sync(lfs_t *lfs, lfs_file_t *file);
 
 // Read data from file
 //

--- a/lfs.h
+++ b/lfs.h
@@ -554,7 +554,7 @@ lfs_soff_t lfs_file_tell(lfs_t *lfs, lfs_file_t *file);
 //
 // Equivalent to lfs_file_seek(lfs, file, 0, LFS_SEEK_SET)
 // Returns a negative error code on failure.
-int lfs_file_rewind(lfs_t *lfs, lfs_file_t *file);
+lfs_soff_t lfs_file_rewind(lfs_t *lfs, lfs_file_t *file);
 
 // Return the size of the file
 //

--- a/lfs.h
+++ b/lfs.h
@@ -574,7 +574,7 @@ int lfs_mkdir(lfs_t *lfs, const char *path);
 //
 // Once open a directory can be used with read to iterate over files.
 // Returns a negative error code on failure.
-int lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path);
+lfs_stag_t lfs_dir_open(lfs_t *lfs, lfs_dir_t *dir, const char *path);
 
 // Close a directory
 //

--- a/lfs.h
+++ b/lfs.h
@@ -608,7 +608,7 @@ lfs_soff_t lfs_dir_tell(lfs_t *lfs, lfs_dir_t *dir);
 // Change the position of the directory to the beginning of the directory
 //
 // Returns a negative error code on failure.
-int lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir);
+lfs_stag_t lfs_dir_rewind(lfs_t *lfs, lfs_dir_t *dir);
 
 
 /// Filesystem-level filesystem operations

--- a/lfs.h
+++ b/lfs.h
@@ -498,7 +498,7 @@ int lfs_file_open(lfs_t *lfs, lfs_file_t *file,
 // config struct must be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
-int lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
+lfs_stag_t lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags,
         const struct lfs_file_config *config);
 

--- a/lfs.h
+++ b/lfs.h
@@ -628,7 +628,7 @@ lfs_ssize_t lfs_fs_size(lfs_t *lfs);
 // blocks are in use or how much of the storage is available.
 //
 // Returns a negative error code on failure.
-int lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
+lfs_stag_t lfs_fs_traverse(lfs_t *lfs, int (*cb)(void*, lfs_block_t), void *data);
 
 #ifdef LFS_MIGRATE
 // Attempts to migrate a previous version of littlefs

--- a/lfs.h
+++ b/lfs.h
@@ -542,7 +542,7 @@ lfs_soff_t lfs_file_seek(lfs_t *lfs, lfs_file_t *file,
 // Truncates the size of the file to the specified size
 //
 // Returns a negative error code on failure.
-int lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
+lfs_soff_t lfs_file_truncate(lfs_t *lfs, lfs_file_t *file, lfs_off_t size);
 
 // Return the position of the file
 //

--- a/lfs.h
+++ b/lfs.h
@@ -436,7 +436,7 @@ int lfs_remove(lfs_t *lfs, const char *path);
 // If the destination is a directory, the directory must be empty.
 //
 // Returns a negative error code on failure.
-int lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath);
+lfs_stag_t lfs_rename(lfs_t *lfs, const char *oldpath, const char *newpath);
 
 // Find info about a file or directory
 //

--- a/lfs.h
+++ b/lfs.h
@@ -485,7 +485,7 @@ int lfs_removeattr(lfs_t *lfs, const char *path, uint8_t type);
 // are values from the enum lfs_open_flags that are bitwise-ored together.
 //
 // Returns a negative error code on failure.
-int lfs_file_open(lfs_t *lfs, lfs_file_t *file,
+lfs_stag_t lfs_file_open(lfs_t *lfs, lfs_file_t *file,
         const char *path, int flags);
 
 // Open a file with extra configuration

--- a/lfs.h
+++ b/lfs.h
@@ -44,6 +44,8 @@ typedef int32_t  lfs_soff_t;
 
 typedef uint32_t lfs_block_t;
 
+typedef int32_t lfs_stag_t;
+
 // Maximum name size in bytes, may be redefined to reduce the size of the
 // info struct. Limited to <= 1022. Stored in superblock and must be
 // respected by other littlefs drivers.

--- a/lfs.h
+++ b/lfs.h
@@ -404,7 +404,7 @@ typedef struct lfs {
 // be zeroed for defaults and backwards compatibility.
 //
 // Returns a negative error code on failure.
-int lfs_format(lfs_t *lfs, const struct lfs_config *config);
+lfs_stag_t lfs_format(lfs_t *lfs, const struct lfs_config *config);
 
 // Mounts a littlefs
 //

--- a/lfs.h
+++ b/lfs.h
@@ -568,7 +568,7 @@ lfs_soff_t lfs_file_size(lfs_t *lfs, lfs_file_t *file);
 // Create a directory
 //
 // Returns a negative error code on failure.
-int lfs_mkdir(lfs_t *lfs, const char *path);
+lfs_stag_t lfs_mkdir(lfs_t *lfs, const char *path);
 
 // Open a directory
 //

--- a/lfs.h
+++ b/lfs.h
@@ -508,7 +508,7 @@ lfs_stag_t lfs_file_opencfg(lfs_t *lfs, lfs_file_t *file,
 // sync had been called and releases any allocated resources.
 //
 // Returns a negative error code on failure.
-int lfs_file_close(lfs_t *lfs, lfs_file_t *file);
+lfs_ssize_t lfs_file_close(lfs_t *lfs, lfs_file_t *file);
 
 // Synchronize a file on storage
 //


### PR DESCRIPTION
In implementing more of the littlefs functionality on a 16 bit machine, found errors in directory traversal, which were a result of data type conversion issues between 16 bit int and the 32 bit size and tag types in littlefs.
Also found that the issue https://github.com/ARMmbed/littlefs/issues/178 was resolved through correcting the type conversions, though can't say which of the changes exactly as I blanket replaced all that I could find.
In hindsight it may have been more straight forward to use a typedef for return type (e.g. typedef int err_ret_t), rather than trying to address each case one by one.
Either way for 16 bit machines, these changes or similar will be needed, so let me know your thoughts as we would like these changes upstream.
I did not address the values in the LFS_MIGRATE section, though technically they should be done too.