### PR TITLE
Update readme example code in accordance to the block_cycles change

### DIFF
--- a/README.md
+++ b/README.md
@@ -53,6 +53,7 @@ const struct lfs_config cfg = {
     .block_count = 128,
     .cache_size = 16,
     .lookahead_size = 16,
+    .block_cycles = 500,
 };
 
 // entry point


### PR DESCRIPTION
An addition to 38a2a8d. When executing the given example in README, you immediately get an assertion error because block_cycles is initiated to 0.