### PR TITLE
Configurable thread-safe littlefs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,6 +27,10 @@ endif
 ifdef TRACE
 override CFLAGS += -DLFS_YES_TRACE
 endif
+ifdef THREAD_SAFE
+override CFLAGS += -DLFS_THREAD_SAFE
+endif
+
 override CFLAGS += -I.
 override CFLAGS += -std=c99 -Wall -pedantic
 override CFLAGS += -Wextra -Wshadow -Wjump-misses-init -Wundef

--- a/lfs.h
+++ b/lfs.h
@@ -174,6 +174,15 @@ struct lfs_config {
     // are propogated to the user.
     int (*sync)(const struct lfs_config *c);
 
+#ifdef LFS_THREAD_SAFE
+    void *lock;
+
+    // Continously tries to acquire the given lock
+    int (*spinlock_lock)(void *lock);
+    // Releases the given lock
+    int (*spinlock_unlock)(void *lock);
+#endif
+
     // Minimum size of a block read. All read operations will be a
     // multiple of this value.
     lfs_size_t read_size;
@@ -421,6 +430,21 @@ int lfs_mount(lfs_t *lfs, const struct lfs_config *config);
 int lfs_unmount(lfs_t *lfs);
 
 /// General operations ///
+
+#ifdef LFS_THREAD_SAFE
+// Continously tries to acquire the lock of the given lfs instance.
+//
+// Basically a nice wrapper to the spinlock_lock function pointer
+// that was assigned previously.
+// Returns the error code of the spinlock_lock function.
+int lfs_acquire_lock(lfs_t *lfs);
+
+// Releases the lock of the given lfs instance.
+//
+// Basically a nice wrapper to the spinlock_unlock function pointer
+// that was assigned previously.
+void lfs_release_lock(lfs_t *lfs);
+#endif
 
 // Removes a file or directory
 //


### PR DESCRIPTION
Configurable thread-safe littlefs.
Closes https://github.com/ARMmbed/littlefs/issues/156

Not sure if that's the best approach. Other options that I thought of raised some problems, for example:
1. Queuing littlefs callbacks and invoke them one by one from a different thread, but:
a. I don't want to make the user create a thread for littlefs due to a possible limitations in embedded devices.
b.  In order to queue a callback and invoke it later, I need to save the buffers (of `lfs_file_write`, `lfs_setattr` etc), which may be a problem.

2. use rwlock on `lfs`, but that won't really solve the problem.

So eventually I just decided to lock an entire littlefs function execution using a spinlock. To do so, I make sure that `lfs_malloc` and `lfs_free` won't be executed inside littlefs function (except `lfs_format` and `lfs_mount`). Also I assume that the read,prog,sync and erase callbacks that are given to `lfs` struct can be called inside a spinlock context.

This "feature" requires pointers to spinlock_lock and spinlock_unlock functions (As we don't want + can't add a "generic" spinlock implementation to the project), and exposes a nice `lfs_acquire_lock` and `lfs_release_lock` to wrap littlefs functions.

I test it locally simply by creating two threads, each one reads and writes to the same file thousands of times. By disabling this feature, the program aborted in one of the `lfs_file_opencfg` call from one of the threads (it happens everytime, not just once or twice). Enabling this feature and wrap the open, read write and close calls with the `lfs_acquire_lock` and `lfs_release_lock` solved the problem.
Do you have any suggestion how can I add a generic test for this project?

Btw, the diff between the sizes of my test binary with and without this feature is 152 bytes.

Anyway, If you have a better solution for a thread-safe littlefs I would be glad to hear.