### PR TITLE
Fixed lfs_dir_fetchmatch not understanding overwritten tags

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,6 +20,7 @@ script:
   # run tests with a few different configurations
   - make test QUIET=1 CFLAGS+="-DLFS_READ_SIZE=1      -DLFS_CACHE_SIZE=4"
   - make test QUIET=1 CFLAGS+="-DLFS_READ_SIZE=512    -DLFS_CACHE_SIZE=512 -DLFS_BLOCK_CYCLES=16"
+  - make test QUIET=1 CFLAGS+="-DLFS_READ_SIZE=8      -DLFS_CACHE_SIZE=16  -DLFS_BLOCK_CYCLES=2"
   - make test QUIET=1 CFLAGS+="-DLFS_BLOCK_COUNT=1023 -DLFS_LOOKAHEAD_SIZE=256"
 
   - make clean test QUIET=1 CFLAGS+="-DLFS_INLINE_MAX=0"

--- a/lfs.c
+++ b/lfs.c
@@ -929,6 +929,11 @@ static lfs_stag_t lfs_dir_fetchmatch(lfs_t *lfs,
                 if (res == LFS_CMP_EQ) {
                     // found a match
                     tempbesttag = tag;
+                } else if ((LFS_MKTAG(0x7ff, 0x3ff, 0) & tag) ==
+                        (LFS_MKTAG(0x7ff, 0x3ff, 0) & tempbesttag)) {
+                    // found an identical tag, but contents didn't match
+                    // this must mean that our besttag has been overwritten
+                    tempbesttag = -1;
                 } else if (res == LFS_CMP_GT &&
                         lfs_tag_id(tag) <= lfs_tag_id(tempbesttag)) {
                     // found a greater match, keep track to keep things sorted
@@ -1378,6 +1383,7 @@ static int lfs_dir_split(lfs_t *lfs,
         lfs_mdir_t *dir, const struct lfs_mattr *attrs, int attrcount,
         lfs_mdir_t *source, uint16_t split, uint16_t end) {
     // create tail directory
+    lfs_alloc_ack(lfs);
     lfs_mdir_t tail;
     int err = lfs_dir_alloc(lfs, &tail);
     if (err) {

--- a/tests/test_alloc.sh
+++ b/tests/test_alloc.sh
@@ -250,6 +250,14 @@ scripts/test.py << TEST
     lfs_unmount(&lfs) => 0;
 TEST
 
+## Below, these tests depend _very_ heavily on the geometry of the
+## block device being tested, they should be removed and replaced
+## by generalized tests. For now we'll just skip if the geometry
+## is customized.
+
+if [[ ! $MAKEFLAGS =~ "LFS_BLOCK_CYCLES" ]]
+then
+
 echo "--- Chained dir exhaustion test ---"
 scripts/test.py << TEST
     lfs_mount(&lfs, &cfg) => 0;
@@ -480,5 +488,7 @@ scripts/test.py << TEST
 
     lfs_unmount(&lfs) => 0;
 TEST
+
+fi
 
 scripts/results.py


### PR DESCRIPTION
Sometimes small, single line code change hides behind it a complicated story. This is one of those times.

If you look at this diff, you may note that this is a case of lfs_dir_fetchmatch not correctly handling a tag that invalidates a callback used to search for some condition, in this case a search for a parent, which is invalidated by a later dir tag overwritting the previous dir pair.

But how can this happen? Dir-pair-tags are only overwritten during relocations (when a block goes bad or exceeds the block_cycles config option for dynamic wear-leveling). Other dir operations create new directory entries. And the only lfs_dir_fetchmatch condition that relies on overwrites (as opposed to proper deletes) is when we need to find a directory's parent, an operation that only occurs during a _different_ relocation. And a false _positive_, can only happen if we don't have a parent. Which is really unlikely when we search for directory parents!

This bug and minimal test case was found by Matthew Renzelmann. In a unfortunate series of events, first a file creation causes a directory split to occur. This creates a new, orphaned metadata-pair containing our new file. However, the revision count on this metadata-pair indicates the pair is due for relocation as a part of wear-leveling. Normally, this is fine, even though this metadata-pair has no parent, the lfs_dir_find should return ENOENT and continue without error. However, here we get hit by our fetchmatch bug. A previous, unrelated relocation overwrites a pair which just happens to contain the block allocated for a new metadata-pair. When we search for a parent, lfs_dir_fetchmatch incorrectly finds this old, outdated metadata pair and incorrectly tells our orphan it's found its parent.

As you can imagine the orphan's dissapointment must be immense.

So an unfortunately timed dir split triggers a relocation which incorrectly finds a previously written parent that has been outdated by another relocation.

As a solution we can outdate our found tag if it is overwritten by an exact match during lfs_dir_fetchmatch.

As a part of this I started adding a new set of tests: tests/test_relocations, for aggressive relocations tests. This is already being appended to by https://github.com/ARMmbed/littlefs/pull/329. I suspect relocations is relatively under-tested and is becoming more important due to recent improvements in wear-leveling.