### PR TITLE
README: fix incorrect description

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,7 @@ directory functions, with the deviation that the allocation of filesystem
 structures must be provided by the user.
 
 All POSIX operations, such as remove and rename, are atomic, even in event
-of power-loss. Additionally, no file updates are not actually committed to
+of power-loss. Additionally, file updates are not actually committed to
 the filesystem until sync or close is called on the file.
 
 ## Other notes


### PR DESCRIPTION
PR created for https://github.com/ARMmbed/littlefs/issues/331:

> README: fix incorrect description
>
> In my point of view, file updates will commit to filesystem only when
sync or close. There is a extra word 'no' here.
> 
> Fixes: bdff4bc59eb6 ("Updated DESIGN.md to reflect v2 changes")
> Signed-off-by: liaoweixiong <liaoweixiong@allwinnertech.com>