### PR TITLE
according to spec tag 0x00000000 is not valid

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -266,7 +266,7 @@ typedef int32_t lfs_stag_t;
     (((lfs_tag_t)(type) << 20) | ((lfs_tag_t)(id) << 10) | (lfs_tag_t)(size))
 
 static inline bool lfs_tag_isvalid(lfs_tag_t tag) {
-    return !(tag & 0x80000000);
+    return !(tag & 0x80000000) && tag;
 }
 
 static inline bool lfs_tag_isdelete(lfs_tag_t tag) {


### PR DESCRIPTION
I have encountered crash in lfs_dir_fetchmatch when retrieved tag was 0x00000000 and callback was 0x0. This is the suggested fix.