### PR TITLE
Fix lfs_dir_seek/lfs_dir_tell mismatch

### DIFF
--- a/lfs.c
+++ b/lfs.c
@@ -1503,9 +1503,13 @@ static int lfs_dir_compact(lfs_t *lfs,
                 }
             }
 #ifdef LFS_MIGRATE
-        } else if (lfs_pair_cmp(dir->pair, lfs->root) == 0 && lfs->lfs1) {
-            // we can't relocate our root during migrations, as this would
-            // cause the superblock to get updated, which would clobber v1
+        } else if (lfs->lfs1) {
+            // do not proactively relocate blocks during migrations, this
+            // can cause a number of failure states such: clobbering the
+            // v1 superblock if we relocate root, and invalidating directory
+            // pointers if we relocate the head of a directory. On top of
+            // this, relocations increase the overall complexity of
+            // lfs_migration, which is already a delicate operation.
 #endif
         } else {
             // we're writing too much, time to relocate

--- a/lfs.c
+++ b/lfs.c
@@ -2064,10 +2064,14 @@ int lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
     dir->pos = lfs_min(2, off);
     off -= dir->pos;
 
-    while (off != 0) {
-        dir->id = lfs_min(dir->m.count, off);
-        dir->pos += dir->id;
-        off -= dir->id;
+    // skip superblock entry
+    dir->id = (off > 0 && lfs_pair_cmp(dir->head, lfs->root) == 0);
+
+    while (off > 0) {
+        int diff = lfs_min(dir->m.count - dir->id, off);
+        dir->id += diff;
+        dir->pos += diff;
+        off -= diff;
 
         if (dir->id == dir->m.count) {
             if (!dir->m.split) {
@@ -2080,6 +2084,8 @@ int lfs_dir_seek(lfs_t *lfs, lfs_dir_t *dir, lfs_off_t off) {
                 LFS_TRACE("lfs_dir_seek -> %d", err);
                 return err;
             }
+
+            dir->id = 0;
         }
     }
 


### PR DESCRIPTION
See https://github.com/ARMmbed/littlefs/issues/328

The superblock entry takes up id 0 in the root directory (not all entries are files, though currently the superblock is the only exception). Normally, reading a directory correctly skips the superblock and only reports non-superblock files.

However, this doesn't work perfectly for lfs_dir_seek, which tries to be clever to not touch the disk.

Fortunately, we can fix this by adding an offset for the superblock. This will only work while the superblock is the only non-file entry, otherwise we would need to touch the disk to properly seek in a
directory (though we already touch the disk a bit to get dir-tails during seeks).

Found by @jhartika
Related https://github.com/ARMmbed/littlefs/issues/328